### PR TITLE
Optimizations for UniversalKriging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+*.egg-info/
+build/
+*.swp

--- a/pykrige/test.py
+++ b/pykrige/test.py
@@ -497,16 +497,17 @@ class TestPyKrigeOpt(unittest.TestCase):
         data = np.random.rand(100, 3)
 
         self.gridx = np.linspace(0.0, 1, 20)
-        self.gridy = np.linspace(0.0, 1, 20)
+        self.gridy = np.linspace(0.0, 1, 30)
         self.UK = UniversalKriging(data[:, 0], data[:, 1], data[:, 2], variogram_model='linear',
                                       drift_terms=['regional_linear'])
 
     def test_uk_python_backend(self):
         """ Compare the optimised version with the original implementation """
         z, ss = self.UK.execute('grid', self.gridx, self.gridy)
-        z2, ss2 = self.UK.cexecute('grid', self.gridx, self.gridy)
+        z2, ss2 = self.UK.cexecute('grid', self.gridx, self.gridy, backend='python')
         self.assertTrue(np.allclose(z, z2))
         self.assertTrue(np.allclose(ss, ss2))
+
 
 
 if __name__ == '__main__':

--- a/pykrige/test.py
+++ b/pykrige/test.py
@@ -508,6 +508,12 @@ class TestPyKrigeOpt(unittest.TestCase):
         self.assertTrue(np.allclose(z, z2))
         self.assertTrue(np.allclose(ss, ss2))
 
+    def test_uk_vectorized_backend(self):
+        """ Compare the optimised version with the original implementation """
+        z, ss = self.UK.execute('grid', self.gridx, self.gridy)
+        z2, ss2 = self.UK.cexecute('grid', self.gridx, self.gridy, backend='vectorized')
+        self.assertTrue(np.allclose(z, z2))
+        self.assertTrue(np.allclose(ss, ss2))
 
 
 if __name__ == '__main__':

--- a/pykrige/test.py
+++ b/pykrige/test.py
@@ -492,6 +492,22 @@ class TestPyKrige(unittest.TestCase):
         self.assertFalse(np.allclose(np.ravel(z), data[:, 2]))
         self.assertFalse(np.allclose(ss, 0.))
 
+class TestPyKrigeOpt(unittest.TestCase):
+    def setUp(self):
+        data = np.random.rand(100, 3)
+
+        self.gridx = np.linspace(0.0, 1, 20)
+        self.gridy = np.linspace(0.0, 1, 20)
+        self.UK = UniversalKriging(data[:, 0], data[:, 1], data[:, 2], variogram_model='linear',
+                                      drift_terms=['regional_linear'])
+
+    def test_uk_python_backend(self):
+        """ Compare the optimised version with the original implementation """
+        z, ss = self.UK.execute('grid', self.gridx, self.gridy)
+        z2, ss2 = self.UK.cexecute('grid', self.gridx, self.gridy)
+        self.assertTrue(np.allclose(z, z2))
+        self.assertTrue(np.allclose(ss, ss2))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pykrige/uk.py
+++ b/pykrige/uk.py
@@ -980,16 +980,18 @@ class UniversalKriging:
         bd = cdist(data, grid, 'euclidean').reshape(n, ny, nx)
         #bd = np.sqrt((data_x_3d - grid_x_3d)**2 + (data_y_3d - grid_y_3d)**2)
 
-        #if np.any(np.absolute(bd) <= self.eps):
-        #    zero_value = True
-        #    zero_index = np.where(np.absolute(bd) <= self.eps)
+        if np.any(np.absolute(bd) <= self.eps):
+            zero_value = True
+            zero_index = np.where(np.absolute(bd) <= self.eps)
+        else:
+            zero_value = False
         if self.UNBIAS:
             b = np.zeros((n_withdrifts+1, ny, nx))
         else:
             b = np.zeros((n_withdrifts+1, ny, nx))
         b[:n, :, :] = - self.variogram_function(self.variogram_model_parameters, bd)
-        #if zero_value:
-        #    b[zero_index[0], zero_index[1], zero_index[2]] = 0.0
+        if zero_value:
+            b[zero_index[0], zero_index[1], zero_index[2]] = 0.0
 
         i = n
         if self.regional_linear_drift:

--- a/pykrige/uk.py
+++ b/pykrige/uk.py
@@ -847,92 +847,8 @@ class UniversalKriging:
         return zvalues, sigmasq
 
 
-
-    def _krige_with_drifts(self, x, y, z, coords):
-        # Sets up and solves the kriging matrix for the given coordinate pair.
-        # Utilizes drift terms.
-
-        x1, x2 = np.meshgrid(x, x)
-        y1, y2 = np.meshgrid(y, y)
-        d = np.sqrt((x1 - x2)**2 + (y1 - y2)**2)
-        bd = np.sqrt((x - coords[0])**2 + (y - coords[1])**2)
-
-        n = x.shape[0]
-        n_withdrifts = n
-        if self.regional_linear_drift:
-            n_withdrifts += 2
-        if self.point_log_drift:
-            n_withdrifts += self.point_log_array.shape[0]
-        if self.external_Z_drift:
-            n_withdrifts += 1
-        if self.UNBIAS:
-            A = np.zeros((n_withdrifts + 1, n_withdrifts + 1))
-        else:
-            A = np.zeros((n_withdrifts, n_withdrifts))
-        A[:n, :n] = - self.variogram_function(self.variogram_model_parameters, d)
-
-        np.fill_diagonal(A, 0.0)
-        index = n
-        if self.regional_linear_drift:
-            A[:n, index] = x
-            A[index, :n] = x
-            index += 1
-            A[:n, index] = y
-            A[index, :n] = y
-            index += 1
-        if self.point_log_drift:
-            for well_no in range(self.point_log_array.shape[0]):
-                dist = np.sqrt((x - self.point_log_array[well_no, 0])**2 +
-                               (y - self.point_log_array[well_no, 1])**2)
-                A[:n, index] = - self.point_log_array[well_no, 2] * np.log(dist)
-                A[index, :n] = - self.point_log_array[well_no, 2] * np.log(dist)
-                index += 1
-        if self.external_Z_drift:
-            A[:n, index] = self.z_scalars
-            A[index, :n] = self.z_scalars
-            index += 1
-        if index != n_withdrifts:
-            print "WARNING: Error in creating kriging matrix. Kriging may fail."
-        if self.UNBIAS:
-            A[n_withdrifts, :n] = 1.0
-            A[:n, n_withdrifts] = 1.0
-            A[n:n_withdrifts + 1, n:n_withdrifts + 1] = 0.0
-
-        if self.UNBIAS:
-            b = np.zeros((n_withdrifts + 1, 1))
-        else:
-            b = np.zeros((n_withdrifts, 1))
-        b[:n, 0] = - self.variogram_function(self.variogram_model_parameters, bd)
-        index = n
-        if self.regional_linear_drift:
-            b[index, 0] = coords[0]
-            index += 1
-            b[index, 0] = coords[1]
-            index += 1
-        if self.point_log_drift:
-            for well_no in range(self.point_log_array.shape[0]):
-                dist = np.sqrt((coords[0] - self.point_log_array[well_no, 0])**2 +
-                               (coords[1] - self.point_log_array[well_no, 1])**2)
-                b[index, 0] = - self.point_log_array[well_no, 2] * np.log(dist)
-                index += 1
-        if self.external_Z_drift:
-            b[index, 0] = self._calculate_data_point_zscalars(np.array([coords[0]]),
-                                                              np.array([coords[1]]))
-            index += 1
-        if index != n_withdrifts:
-            print "WARNING: Error in setting up kriging system. Kriging may fail."
-        if self.UNBIAS:
-            b[n_withdrifts, 0] = 1.0
-
-        x = np.linalg.solve(A, b)
-        zinterp = np.sum(x[:n, 0] * z)
-        sigmasq = np.sum(x[:, 0] * -b[:, 0])
-
-        return zinterp, sigmasq
-
     def _inverse_system(self, x, y, z):
-        # Sets up and solves the kriging matrix for the given coordinate pair.
-        # Utilizes drift terms.
+        """ Set up the kriging matrix and calculate compute it's inverse """
 
         x1, x2 = np.meshgrid(x, x)
         y1, y2 = np.meshgrid(y, y)
@@ -975,7 +891,9 @@ class UniversalKriging:
             A[n:n_withdrifts + 1, n:n_withdrifts + 1] = 0.0
         return scipy.linalg.inv(A)
 
+
     def _set_n_withdrifts(self, x):
+        """ Helper function to set n_withdrifts (internal use only) """
         n = x.shape[0]
         n_withdrifts = n
         if self.regional_linear_drift:
@@ -1014,14 +932,16 @@ class UniversalKriging:
         if self.UNBIAS:
             b[n_withdrifts, 0] = 1.0
 
-        x = np.dot(Ai, b)
-        zinterp = np.sum(x[:n, 0] * z)
-        sigmasq = np.sum(x[:, 0] * -b[:, 0])
+        res = np.dot(Ai, b)
+        zinterp = np.sum(res[:n, 0] * z)
+        sigmasq = np.sum(res[:, 0] * -b[:, 0])
 
         return zinterp, sigmasq
 
+
     def _python_loop(self, grid_x, grid_y, x_adjusted, y_adjusted, z_in, Ai, b):
-            
+            """ Main loop that calculate kriging on the grid""" 
+
             nx, ny = grid_x.shape
             gridz = np.zeros((ny, nx))
             sigmasq = np.zeros((ny, nx))
@@ -1037,7 +957,9 @@ class UniversalKriging:
                     sigmasq[m, n] = ss
             return gridz, sigmasq
 
+
     def cexecute(self, style, xpoints, ypoints, mask=None, backend='python'):
+        """ Optimised version of execute. See execute.__doc__ ."""
 
         if self.verbose:
             print "Executing Universal Kriging...\n"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from os.path import join
 
 setup(name='PyKrige',


### PR DESCRIPTION
Following explanations in the feature request https://github.com/bsmurphy/PyKrige/issues/2, this PR reintroduces code from v1.0.0 (https://github.com/bsmurphy/PyKrige/commit/3bf98a1d47b7562842571c0c1abe4f765e210657) for UniversalKriging  where it is computed with a loop. 

In the version https://github.com/bsmurphy/PyKrige/commit/3bf98a1d47b7562842571c0c1abe4f765e210657, in every loop an `A` matrix is defined together with a second member `b` and the system is `A x = b` then solved with `np.linalg.solve`. 

This PR, just  factorizes the matrix definition outside of the python loop, and computes it's inverse. The `x` vector can be obtained by `A^(-1) b`, which is much faster once we have inverted the matrix. This result in (a) reducing the required RAM, compared to the all vectorized version (b) speed up the code by a factor of ~15  (for `nx=100`, `ny=200`, `n=100`).

Everything is defined in the `cexecute` function, alongside the original `execute` function. A typical use would be,
 
     z, ss = UK.cexecute('grid', gridx, gridy, backend='python')

There are some additional tests in `tests.py` to check that both versions give the same output (although this might need to be tested more).

**Edit:**

Added a vectorized pure python version (without the loop), that is ~4-6x faster, but requires more RAM (e.g. 6 GB of RAM for nx=1000, ny=1000, npt=100).  It can be accessed through,
 
     z, ss = UK.cexecute('grid', gridx, gridy, backend='vectorized')
