### PR TITLE
Fixing Travis-CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ install:
     - conda install --yes -c conda conda-env
     - conda create -n krige-env --yes $DEPS pip python=${TRAVIS_PYTHON_VERSION}
     - echo $PATH
+    - ls /home/travis/miniconda${TRAVIS_PYTHON_VERSION:0:1}/bin
+    - conda info -a
     - source activate krige-env; which python
     - pip install coveralls 
     - which python

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
 
 # setup adapted from https://github.com/soft-matter/trackpy/blob/master/.travis.yml
 before_install:
-    - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
+    - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
     - chmod +x miniconda.sh
     - ./miniconda.sh -b
     - export PATH=/home/travis/miniconda${TRAVIS_PYTHON_VERSION:0:1}/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ before_install:
     - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
     - chmod +x miniconda.sh
     - ./miniconda.sh -b
-    - export PATH=/home/travis/miniconda/bin:$PATH
-    - export PATH=/home/travis/miniconda3/bin:$PATH
+    - export PATH=/home/travis/miniconda${TRAVIS_PYTHON_VERSION:0:1}/bin:$PATH
     # See:
     # https://groups.google.com/a/continuum.io/forum/#!topic/conda/RSFENqovnro
     - conda update --yes --no-deps conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
 
 # setup adapted from https://github.com/soft-matter/trackpy/blob/master/.travis.yml
 before_install:
-    - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-3.16.0-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-3.16.0-Linux-x86_64.sh -O miniconda.sh; fi
+    - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
     - chmod +x miniconda.sh
     - ./miniconda.sh -b
     - export PATH=/home/travis/miniconda/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ install:
     - conda create -n krige-env --yes $DEPS pip python=${TRAVIS_PYTHON_VERSION}
     - source activate krige-env
     - pip install coveralls 
+    - which python
+    - python -c 'import scipy; print("ok");'
     - python setup.py build_ext --inplace
     - python setup.py install
     - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ before_install:
 install: 
     - conda install --yes -c conda conda-env
     - conda create -n krige-env --yes $DEPS pip python=${TRAVIS_PYTHON_VERSION}
-    - source activate krige-env
+    - echo $PATH
+    - source activate krige-env; which python
     - pip install coveralls 
     - which python
     - python -c 'import scipy; print("ok");'

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,10 @@ before_install:
 
 install: 
     - conda install --yes -c conda conda-env
-    - conda create -n krige-env --yes $DEPS pip python=${TRAVIS_PYTHON_VERSION}
-    - echo $PATH
-    - ls /home/travis/miniconda${TRAVIS_PYTHON_VERSION:0:1}/bin
+    - conda install --yes $DEPS pip
     - conda info -a
-    - source activate krige-env; which python
     - pip install coveralls 
     - which python
-    - python -c 'import scipy; print("ok");'
     - python setup.py build_ext --inplace
     - python setup.py install
     - cd ..

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ for req in REQ:
               "installation, please view https://www.scipy.org/install.html.")
         print("       {}  not found!".format(req))
         print("**************************************************")
-        sys.exit(1)
+        raise
 # python setup.py install goes through REQ in reverse order than pip
 
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ for req in REQ:
         print("Error: PyKrige relies on the installation of the SciPy stack "
               "(Numpy, SciPy, matplotlib) to work. For instructions for "
               "installation, please view https://www.scipy.org/install.html.")
+        print("       {}  not found!".format(req))
         print("**************************************************")
         sys.exit(1)
 # python setup.py install goes through REQ in reverse order than pip


### PR DESCRIPTION
Following the discussin in PR #15 , this fixes some issues with the Travis-CI setup, and in particular,

 - updates the miniconda.sh executable to the last version
 - removes the use of conda virtual env as this was not working: `source activate pykrige-env` executed but didn't do anything, the `python` command was still loading the default python environement not the one in miniconda (not sure why), which resulted in the scipy import issue.
 - also rasing an exception if any of the dependencies are not installed (in adition to the prevously added custom message) so it's easier to debug.