### PR TITLE
Added Cython support for python 3

### DIFF
--- a/pykrige/lib/lapack_py3.pxd
+++ b/pykrige/lib/lapack_py3.pxd
@@ -1,0 +1,32 @@
+cimport numpy as np
+
+ctypedef int dgemv_t(
+        # Compute y := alpha*A*x + beta*y
+        char *trans, # {'T','C'}: o(A)=A'; {'N'}: o(A)=A
+        int *m, # Rows of A (prior to transpose from *trans)
+        int *n, # Columns of A / min(len(x))
+        np.float64_t *alpha, # Scalar multiple
+        np.float64_t *a, # Matrix A: mxn
+        int *lda, # The size of the first dimension of A (in memory)
+        np.float64_t *x, # Vector x, min(len(x)) = n
+        int *incx, # The increment between elements of x (usually 1)
+        np.float64_t *beta, # Scalar multiple
+        np.float64_t *y, # Vector y, min(len(y)) = m
+        int *incy # The increment between elements of y (usually 1)
+        )
+
+ctypedef int dgesv_t(
+        # Solve A*x=b
+        int *n, #  The number of linear equations,
+        int *nrhs, #  The number of right hand sides, i.e.,  the  number of columns of the matrix B.  NRHS >= 0.
+        np.float64_t *a, # Matrix A: mxn
+        int *lda, # The size of the first dimension of A (in memory)
+        int *ipiv, # Integer array
+        np.float64_t *b, # Vector b
+        int *ldb, # The size of the first dimension of A (in memory)
+        int *info, # The size of the first dimension of A (in memory)
+        )
+
+cdef dgemv_t *dgemv
+
+cdef dgesv_t *dgesv

--- a/pykrige/lib/lapack_py3.pyx
+++ b/pykrige/lib/lapack_py3.pyx
@@ -1,0 +1,33 @@
+# cython: profile=False
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: cdivision=True
+import numpy as np
+cimport numpy as np
+import scipy.linalg.blas
+import scipy.linalg.lapack
+#from cpython.cobject cimport PyCObject_AsVoidPtr # only works with python 2, use capsules for python 3
+from cpython.pycapsule cimport PyCapsule_GetPointer
+
+cdef extern from "Python.h":
+    void PyErr_Clear()
+
+
+np.import_array()
+
+
+# Snippet adapted from
+# https://github.com/statsmodels/statsmodels/blob/master/statsmodels/src/capsule.h
+cdef void* Capsule_AsVoidPtr(object obj):
+    cdef void* ret = PyCapsule_GetPointer(obj, NULL);
+    if (ret == NULL):
+        PyErr_Clear()
+    return ret
+
+
+# interface to BLAS matrix-vector multipilcation though scipy.linalg 
+# adapted from
+# https://github.com/statsmodels/statsmodels/blob/master/statsmodels/tsa/kalmanf/kalman_loglike.pyx
+
+cdef dgemv_t *dgemv = <dgemv_t*>Capsule_AsVoidPtr(scipy.linalg.blas.get_blas_funcs('gemv', dtype='float64')._cpointer)
+cdef dgesv_t *dgesv = <dgesv_t*>Capsule_AsVoidPtr(scipy.linalg.lapack.get_lapack_funcs('gesv', dtype='float64')._cpointer)

--- a/setup.py
+++ b/setup.py
@@ -90,24 +90,16 @@ def run_setup(with_cython):
                                 extra_link_args=['-O2', '-march=core2', '-mtune=corei7'])
         else:
             compile_args = {}
+        
+        ext_modules = [Extension("pykrige.lib.cok", ["pykrige/lib/cok.pyx"], **compile_args),
+                       Extension("pykrige.lib.variogram_models", ["pykrige/lib/variogram_models.pyx"], **compile_args)]
+        
         # Transfered python 3 switch here. On python 3 machines, will use lapack_py3.pyx
         # instead of lapack.pyx to build .lib.lapack
         if sys.version_info[0] == 3:
-            ext_modules = [Extension("pykrige.lib.cok", ["pykrige/lib/cok.pyx"],
-                                     **compile_args),
-                           Extension("pykrige.lib.lapack", 
-                                     ["pykrige/lib/lapack_py3.pyx"], **compile_args),
-                           Extension("pykrige.lib.variogram_models",
-                                     ["pykrige/lib/variogram_models.pyx"],
-                                     **compile_args)]
+            ext_modules += [Extension("pykrige.lib.lapack", ["pykrige/lib/lapack_py3.pyx"], **compile_args)]
         else:
-            ext_modules = [Extension("pykrige.lib.cok", ["pykrige/lib/cok.pyx"],
-                                     **compile_args),
-                           Extension("pykrige.lib.lapack", ["pykrige/lib/lapack.pyx"],
-                                     **compile_args),
-                           Extension("pykrige.lib.variogram_models",
-                                     ["pykrige/lib/variogram_models.pyx"],
-                                     **compile_args)]
+            ext_modules += [Extension("pykrige.lib.lapack", ["pykrige/lib/lapack.pyx"], **compile_args)]
 
         class TryBuildExt(build_ext):
             def build_extensions(self):

--- a/setup.py
+++ b/setup.py
@@ -47,24 +47,18 @@ CLSF = ['Development Status :: 5 - Production/Stable',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: GIS']
 
-if sys.version_info[0] == 3:
+# Removed python 3 switch from here
+try:
+    from Cython.Distutils import build_ext
+    import Cython.Compiler.Options
+    Cython.Compiler.Options.annotate = False
+    try_cython = True
+except ImportError:
     print("**************************************************")
-    print("WARNING: Currently, Cython extensions are not built when using Python 3. "
-          "This will be changed in the future. Falling back to pure Python implementation.")
+    print("WARNING: Cython is not currently installed. "
+          "Falling back to pure Python implementation.")
     print("**************************************************")
     try_cython = False
-else:
-    try:
-        from Cython.Distutils import build_ext
-        import Cython.Compiler.Options
-        Cython.Compiler.Options.annotate = False
-        try_cython = True
-    except ImportError:
-        print("**************************************************")
-        print("WARNING: Cython is not currently installed. "
-              "Falling back to pure Python implementation.")
-        print("**************************************************")
-        try_cython = False
 
 
 class BuildFailed(Exception):
@@ -96,9 +90,24 @@ def run_setup(with_cython):
                                 extra_link_args=['-O2', '-march=core2', '-mtune=corei7'])
         else:
             compile_args = {}
-        ext_modules = [Extension("pykrige.lib.cok", ["pykrige/lib/cok.pyx"], **compile_args),
-                       Extension("pykrige.lib.lapack", ["pykrige/lib/lapack.pyx"], **compile_args),
-                       Extension("pykrige.lib.variogram_models", ["pykrige/lib/variogram_models.pyx"], **compile_args)]
+        # Transfered python 3 switch here. On python 3 machines, will use lapack_py3.pyx
+        # instead of lapack.pyx to build .lib.lapack
+        if sys.version_info[0] == 3:
+            ext_modules = [Extension("pykrige.lib.cok", ["pykrige/lib/cok.pyx"],
+                                     **compile_args),
+                           Extension("pykrige.lib.lapack", 
+                                     ["pykrige/lib/lapack_py3.pyx"], **compile_args),
+                           Extension("pykrige.lib.variogram_models",
+                                     ["pykrige/lib/variogram_models.pyx"],
+                                     **compile_args)]
+        else:
+            ext_modules = [Extension("pykrige.lib.cok", ["pykrige/lib/cok.pyx"],
+                                     **compile_args),
+                           Extension("pykrige.lib.lapack", ["pykrige/lib/lapack.pyx"],
+                                     **compile_args),
+                           Extension("pykrige.lib.variogram_models",
+                                     ["pykrige/lib/variogram_models.pyx"],
+                                     **compile_args)]
 
         class TryBuildExt(build_ext):
             def build_extensions(self):


### PR DESCRIPTION
I added a workaround to replace the PyCObject_AsVoidPtr that prevented importing the cython module by PyCapsule_GetPointer. Depending on python version, setup.py compiles either lib/lapack.p* or lib/lapack_py3.p*
Code adapted from https://github.com/statsmodels/statsmodels/blob/master/statsmodels/src/capsule.h

Was so far tested only with test.py (and on python 3), which ran without errors.