### PR TITLE
Fixing the Travis CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - python: "3.4"                                                                                         
       env: DEPS="numpy=1.10.4 scipy=0.17 cython nose matplotlib"
     - python: "2.7"                                                                                         
-      env: DEPS="numpy=1.9.2 scipy=0.16 cython nose matplotlib"
+      env: DEPS="numpy=1.9.2 scipy=0.17 cython nose matplotlib"
 
 # setup adapted from https://github.com/soft-matter/trackpy/blob/master/.travis.yml
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,22 +2,21 @@ language: python
 sudo: false
 matrix:
     include:
-    - python: "3.4"
-      env: DEPS="numpy scipy nose matplotlib cython"
-    - python: "2.7"
-      env: DEPS="numpy=1.10.4 scipy=0.17 nose matplotlib cython"
+    - python: "3.5"
+      env: DEPS="numpy=1.11.2 scipy=0.18.1 cython nose matplotlib"
+    - python: "3.4"                                                                                         
+      env: DEPS="numpy=1.10.4 scipy=0.17 cython nose matplotlib"
+    - python: "2.7"                                                                                         
+      env: DEPS="numpy=1.9.2 scipy=0.16 cython nose matplotlib"
 
 # setup adapted from https://github.com/soft-matter/trackpy/blob/master/.travis.yml
 before_install:
-    - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
+    - wget http://repo.continuum.io/miniconda/Miniconda${TRAVIS_PYTHON_VERSION:0:1}-latest-Linux-x86_64.sh -O miniconda.sh
     - chmod +x miniconda.sh
     - ./miniconda.sh -b
     - export PATH=/home/travis/miniconda${TRAVIS_PYTHON_VERSION:0:1}/bin:$PATH
-    # See:
-    # https://groups.google.com/a/continuum.io/forum/#!topic/conda/RSFENqovnro
-    - conda update --yes --no-deps conda
-    # Learned the hard way: miniconda is not always up-to-date with conda.
     - conda update --yes conda
+    - conda info -a
 
 install: 
     - conda install --yes -c conda conda-env
@@ -34,7 +33,6 @@ install:
 script: 
     - cd ./PyKrige/pykrige/
     - nosetests ./test.py --with-coverage --cover-package=pykrige
-#    - coverage run --source=hedp ./hedp/tests/run.py
 
 #after_success:
 #    coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - python: "3.4"                                                                                         
       env: DEPS="numpy=1.10.4 scipy=0.17 cython nose matplotlib"
     - python: "2.7"                                                                                         
-      env: DEPS="numpy=1.9.2 scipy=0.17 cython nose matplotlib"
+      env: DEPS="numpy=1.10.4 scipy=0.17 cython nose matplotlib"
 
 # setup adapted from https://github.com/soft-matter/trackpy/blob/master/.travis.yml
 before_install:
@@ -19,9 +19,7 @@ before_install:
     - conda info -a
 
 install: 
-    - conda install --yes -c conda conda-env
     - conda install --yes $DEPS pip
-    - conda info -a
     - pip install coveralls 
     - which python
     - python setup.py build_ext --inplace

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,12 @@ for req in REQ:
         print("**************************************************")
         print("Error: PyKrige relies on the installation of the SciPy stack "
               "(Numpy, SciPy, matplotlib) to work. For instructions for "
-              "installation, please view https://www.scipy.org/install.html.")
-        print("       {}  not found!".format(req))
+              "installation, please view https://www.scipy.org/install.html."
+              "\n {} missing".format(req) 
+              )
         print("**************************************************")
         raise
+        sys.exit(1)
 # python setup.py install goes through REQ in reverse order than pip
 
 


### PR DESCRIPTION
An update of the Travis CI setup to fix issues encountered by @mjziebarth in PR #18 .
   - testing broader set of numpy / scipy versions
   - adding tests for Python 3.5
   - ~~using the latest miniconda~~
   - ~~made the message of missing dependencies in `setup.py` more verbose (it is hard to debug otherwise)~~
   - ~~removing the conda virtualenv which was not working properly anyway it appears.~~

**Edit:**  sorry, some of this was already done earlier, was not using the latest version.

Could someone please review this PR, @bsmurphy , @mjziebarth ?