### PR TITLE
fix Cython extension importing error.

### DIFF
--- a/pykrige/lib/__init__.py
+++ b/pykrige/lib/__init__.py
@@ -1,3 +1,1 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
-
+__all__ = ['cok', 'lapack', 'variogram_models']


### PR DESCRIPTION
It seems that pip will not install an empty **init**.py into submodule folder. I made this fix and it works well on my Fedora 23.
