### PR TITLE
Added support for spherical coordinates

### DIFF
--- a/pykrige/core.py
+++ b/pykrige/core.py
@@ -59,9 +59,40 @@ from scipy.optimize import minimize
 
 
 def great_circle_distance(lon1, lat1, lon2, lat2):
+    """
+    Calculate the great circle distance between one or multiple
+    pairs of points on a unit sphere.
+    
+    Parameters:
+    -----------
+    lon1: float scalar or numpy array
+        Longitude coordinate(s) of the first element(s) of the point
+        pair(s), given in degrees.
+    lat1: float scalar or numpy array
+        Latitude coordinate(s) of the first element(s) of the point
+        pair(s), given in degrees.
+    lon2: float scalar or numpy array
+        Longitude coordinate(s) of the second element(s) of the point
+        pair(s), given in degrees.
+    lat2: float scalar or numpy array
+        Latitude coordinate(s) of the second element(s) of the point
+        pair(s), given in degrees.
+    
+    Calculation of distances follows numpy elementwise semantics, so if
+    an array of length N is passed, all input parameters need to be
+    arrays of length N or scalars.
+    
+    
+    Returns:
+    --------
+    distance: float
+              The great circle distance(s) (in degrees) between the
+              given pair(s) of points.
+    
+    """
     # Calculate dot product of both vectors:
-    lat1 *= np.pi/180.0
-    lat2 *= np.pi/180.0
+    lat1 = np.array(lat1)*np.pi/180.0
+    lat2 = np.array(lat2)*np.pi/180.0
     d = np.cos((lon1-lon2)*np.pi/180.0)*np.cos(lat1)*np.cos(lat2) \
         + np.sin(lat1)*np.sin(lat2)
     # Angle is arccos of dot product. Avoid errors caused
@@ -71,8 +102,24 @@ def great_circle_distance(lon1, lat1, lon2, lat2):
     return 180.0/np.pi*np.arccos(d)
 
 def euclid3_to_great_circle(euclid3_distance):
-    """Convert euclidean distance between points on a unit sphere to
-    the corresponding great circle distance."""
+    """
+    Convert euclidean distance between points on a unit sphere to
+    the corresponding great circle distance.
+    
+    
+    Parameters:
+    -----------
+    euclid3_distance: float scalar or numpy array
+        The euclidean three-space distance(s) between points on a
+        unit sphere, thus between [0,2].
+    
+    
+    Returns:
+    --------
+    great_circle_dist: float scalar or numpy array
+        The corresponding great circle distance(s) between the
+        points.
+    """
     # Eliminate some possible numerical errors:
     euclid3_distance[euclid3_distance>2.0] = 2.0
     return 180.0 - 360.0/np.pi*np.arccos(0.5*euclid3_distance)

--- a/pykrige/core.py
+++ b/pykrige/core.py
@@ -90,13 +90,15 @@ def great_circle_distance(lon1, lat1, lon2, lat2):
               given pair(s) of points.
     
     """
-    # Calculate dot product of both vectors:
+    # Calculate dot product of both euclidean vectors:
     lat1 = np.array(lat1)*np.pi/180.0
     lat2 = np.array(lat2)*np.pi/180.0
     d = np.cos((lon1-lon2)*np.pi/180.0)*np.cos(lat1)*np.cos(lat2) \
         + np.sin(lat1)*np.sin(lat2)
-    # Angle is arccos of dot product. Avoid errors caused
-    # by numerics:
+    # Angle is arccos of euclidean dot product. Avoid errors caused
+    # by numerics (possibly d>1.0 or d<-1.0, resulting in NAN. This
+    # can, however, only be caused by numerical errors for real
+    # lat/lon):
     d[d>1.0] = 1.0
     d[d<-1.0]=-1.0
     return 180.0/np.pi*np.arccos(d)

--- a/pykrige/core.py
+++ b/pykrige/core.py
@@ -42,6 +42,10 @@ Functions:
         Returns the Q2 statistic for the variogram fit (see Kitanidis).
     calc_cR(Q2, sigma):
         Returns the cR statistic for the variogram fit (see Kitanidis).
+    great_circle_distance(lon1, lat1, lon2, lat2):
+        Returns the great circle distance between two arrays of points given in spherical
+        coordinates. Spherical coordinates are expected in degrees. Angle definition
+        follows standard longitude/latitude definition.
 
 References:
     P.K. Kitanidis, Introduction to Geostatistcs: Applications in Hydrogeology,
@@ -52,6 +56,26 @@ Copyright (c) 2015 Benjamin S. Murphy
 
 import numpy as np
 from scipy.optimize import minimize
+
+
+def great_circle_distance(lon1, lat1, lon2, lat2):
+    # Calculate dot product of both vectors:
+    lat1 *= np.pi/180.0
+    lat2 *= np.pi/180.0
+    d = np.cos((lon1-lon2)*np.pi/180.0)*np.cos(lat1)*np.cos(lat2) \
+        + np.sin(lat1)*np.sin(lat2)
+    # Angle is arccos of dot product. Avoid errors caused
+    # by numerics:
+    d[d>1.0] = 1.0
+    d[d<-1.0]=-1.0
+    return 180.0/np.pi*np.arccos(d)
+
+def euclid3_to_great_circle(euclid3_distance):
+    """Convert euclidean distance between points on a unit sphere to
+    the corresponding great circle distance."""
+    # Eliminate some possible numerical errors:
+    euclid3_distance[euclid3_distance>2.0] = 2.0
+    return 180.0 - 360.0/np.pi*np.arccos(0.5*euclid3_distance)
 
 
 def adjust_for_anisotropy(x, y, xcenter, ycenter, scaling, angle):
@@ -117,7 +141,7 @@ def adjust_for_anisotropy_3d(x, y, z, xcenter, ycenter, zcenter, scaling_y,
 
 
 def initialize_variogram_model(x, y, z, variogram_model, variogram_model_parameters,
-                               variogram_function, nlags, weight):
+                               variogram_function, nlags, weight, coordinates_type):
     """Initializes the variogram model for kriging according
     to user specifications or to defaults"""
 
@@ -125,10 +149,16 @@ def initialize_variogram_model(x, y, z, variogram_model, variogram_model_paramet
     y1, y2 = np.meshgrid(y, y)
     z1, z2 = np.meshgrid(z, z)
 
-    dx = x1 - x2
-    dy = y1 - y2
     dz = z1 - z2
-    d = np.sqrt(dx**2 + dy**2)
+#GEO
+    if coordinates_type == 'euclidean':
+        dx = x1 - x2
+        dy = y1 - y2
+        d = np.sqrt(dx**2 + dy**2)
+    elif coordinates_type == 'geographic':
+        # Assume x => lon, y => lat
+        d = great_circle_distance(x1, y1, x2, y2)
+        
     g = 0.5 * dz**2
 
     indices = np.indices(d.shape)
@@ -300,7 +330,7 @@ def calculate_variogram_model(lags, semivariance, variogram_model, variogram_fun
     return res.x
 
 
-def krige(x, y, z, coords, variogram_function, variogram_model_parameters):
+def krige(x, y, z, coords, variogram_function, variogram_model_parameters, coordinates_type):
         """Sets up and solves the kriging matrix for the given coordinate pair.
         This function is now only used for the statistics calculations."""
 
@@ -309,8 +339,14 @@ def krige(x, y, z, coords, variogram_function, variogram_model_parameters):
 
         x1, x2 = np.meshgrid(x, x)
         y1, y2 = np.meshgrid(y, y)
-        d = np.sqrt((x1 - x2)**2 + (y1 - y2)**2)
-        bd = np.sqrt((x - coords[0])**2 + (y - coords[1])**2)
+#GEO
+        if coordinates_type == 'euclidean':
+            d = np.sqrt((x1 - x2)**2 + (y1 - y2)**2)
+            bd = np.sqrt((x - coords[0])**2 + (y - coords[1])**2)
+        elif coordinates_type == 'geographic':
+            d = great_circle_distance(x1, y1, x2, y2)
+            bd = great_circle_distane(x, y, coords[0]*np.ones(x.shape),
+                                      coords[1]*np.ones(y.shape))
         if np.any(np.absolute(bd) <= 1e-10):
             zero_value = True
             zero_index = np.where(bd <= 1e-10)[0][0]
@@ -373,7 +409,7 @@ def krige_3d(x, y, z, vals, coords, variogram_function, variogram_model_paramete
         return zinterp, sigmasq
 
 
-def find_statistics(x, y, z, variogram_function, variogram_model_parameters):
+def find_statistics(x, y, z, variogram_function, variogram_model_parameters, coordinates_type):
     """Calculates variogram fit statistics."""
 
     delta = np.zeros(z.shape)
@@ -384,7 +420,8 @@ def find_statistics(x, y, z, variogram_function, variogram_model_parameters):
             delta[n] = 0.0
             sigma[n] = 0.0
         else:
-            z_, ss_ = krige(x[:n], y[:n], z[:n], (x[n], y[n]), variogram_function, variogram_model_parameters)
+            z_, ss_ = krige(x[:n], y[:n], z[:n], (x[n], y[n]), variogram_function,
+                            variogram_model_parameters, coordinates_type)
             d = z[n] - z_
             delta[n] = d
             sigma[n] = np.sqrt(ss_)

--- a/pykrige/ok.py
+++ b/pykrige/ok.py
@@ -79,15 +79,24 @@ class OrdinaryKriging:
             into account anisotropy. Default is 1 (effectively no stretching).
             Scaling is applied in the y-direction in the rotated data frame
             (i.e., after adjusting for the anisotropy_angle, if anisotropy_angle
-            is not 0).
+            is not 0). This parameter has no effect if coordinate_types is set to
+            'geographic'.
         anisotropy_angle (float, optional): CCW angle (in degrees) by which to
             rotate coordinate system in order to take into account anisotropy.
             Default is 0 (no rotation). Note that the coordinate system is rotated.
+            This parameter has no effect if coordinate_types is set to 'geographic'.
         verbose (Boolean, optional): Enables program text output to monitor
             kriging process. Default is False (off).
         enable_plotting (Boolean, optional): Enables plotting to display
             variogram. Default is False (off).
         enable_statistics (Boolean, optional). Default is False
+        coordinates_type (string, optional): One of 'euclidean' or 'geographic'.
+            Determines if the x and y coordinates are interpreted as on a plane
+            ('euclidean') or as coordinates on a sphere ('geographic'). In
+            case of geographic coordinates, x is interpreted as longitude and
+            y as latitude coordinates, both given in degree. Longitudes are 
+            expected in [0, 360] and latitudes in [-90, 90].
+            Default is 'euclidean'.
 
     Callable Methods:
         display_variogram_model(): Displays semivariogram and variogram model.
@@ -203,7 +212,6 @@ class OrdinaryKriging:
         if self.enable_plotting and self.verbose:
             print("Plotting Enabled\n")
 
-        self.coordinates_type = coordinates_type
         if coordinates_type == 'euclidean':
             self.XCENTER = (np.amax(self.X_ORIG) + np.amin(self.X_ORIG))/2.0
             self.YCENTER = (np.amax(self.Y_ORIG) + np.amin(self.Y_ORIG))/2.0
@@ -218,6 +226,8 @@ class OrdinaryKriging:
         elif coordinates_type == 'geographic':
             # Leave everything as is in geographic case.
             # May be open to discussion?
+            print("Warning: Anisotropy is not compatible with geographic coordinates. "
+                  "Ignoring user set anisotropy.")
             self.XCENTER= 0.0
             self.YCENTER= 0.0
             self.anisotropy_scaling = 1.0
@@ -227,6 +237,7 @@ class OrdinaryKriging:
         else:
             raise ValueError("Only 'euclidean' and 'geographic' are valid values for "
                              "coordinates-keyword.")
+        self.coordinates_type = coordinates_type
 
         self.variogram_model = variogram_model
         if self.variogram_model not in self.variogram_dict.keys() and self.variogram_model != 'custom':

--- a/pykrige/test.py
+++ b/pykrige/test.py
@@ -91,17 +91,19 @@ class TestPyKrige(unittest.TestCase):
 
         # Note the variogram_function argument is not a string in real life...
         self.assertRaises(ValueError, core.initialize_variogram_model, self.test_data[:, 0], self.test_data[:, 1],
-                          self.test_data[:, 2], 'linear', [0.0], 'linear', 6, False)
+                          self.test_data[:, 2], 'linear', [0.0], 'linear', 6, False,
+                          'euclidean')
 
         self.assertRaises(ValueError, core.initialize_variogram_model, self.test_data[:, 0], self.test_data[:, 1],
-                          self.test_data[:, 2], 'spherical', [0.0], 'spherical', 6, False)
+                          self.test_data[:, 2], 'spherical', [0.0], 'spherical', 6, False,
+                          'euclidean')
 
         x = np.array([1.0 + n/np.sqrt(2) for n in range(4)])
         y = np.array([1.0 + n/np.sqrt(2) for n in range(4)])
         z = np.arange(1.0, 5.0, 1.0)
         lags, semivariance, variogram_model_parameters = core.initialize_variogram_model(x, y, z, 'linear',
                                                                                          [0.0, 0.0], 'linear',
-                                                                                         6, False)
+                                                                                         6, False, 'euclidean')
 
         self.assertTrue(np.allclose(lags, np.array([1.0, 2.0, 3.0])))
         self.assertTrue(np.allclose(semivariance, np.array([0.5, 2.0, 4.5])))
@@ -158,12 +160,14 @@ class TestPyKrige(unittest.TestCase):
         data = np.array([[9.7, 47.6, 1.22],
                          [43.8, 24.6, 2.822]])
         z, ss = core.krige(data[:, 0], data[:, 1], data[:, 2], (18.8, 67.9),
-                           variogram_models.linear_variogram_model, [0.006, 0.1])
+                           variogram_models.linear_variogram_model, [0.006, 0.1],
+                           'euclidean')
         self.assertAlmostEqual(z, 1.6364, 4)
         self.assertAlmostEqual(ss, 0.4201, 4)
 
         z, ss = core.krige(data[:, 0], data[:, 1], data[:, 2], (43.8, 24.6),
-                           variogram_models.linear_variogram_model, [0.006, 0.1])
+                           variogram_models.linear_variogram_model, [0.006, 0.1],
+                           'euclidean')
         self.assertAlmostEqual(z, 2.822, 3)
         self.assertAlmostEqual(ss, 0.0, 3)
 
@@ -854,11 +858,13 @@ class TestPyKrige(unittest.TestCase):
         self.assertFalse(np.allclose(ss, 0.))
 
         z, ss = core.krige(data[:, 0], data[:, 1], data[:, 2], (1., 1.),
-                           variogram_models.linear_variogram_model, [1.0, 1.0])
+                           variogram_models.linear_variogram_model, [1.0, 1.0],
+                           'euclidean')
         self.assertAlmostEqual(z, 2.)
         self.assertAlmostEqual(ss, 0.)
         z, ss = core.krige(data[:, 0], data[:, 1], data[:, 2], (1., 2.),
-                           variogram_models.linear_variogram_model, [1.0, 1.0])
+                           variogram_models.linear_variogram_model, [1.0, 1.0],
+                           'euclidean')
         self.assertNotAlmostEqual(ss, 0.)
 
         data = np.zeros((50, 3))
@@ -1384,6 +1390,43 @@ class TestPyKrige(unittest.TestCase):
         z_lin, ss_lin = uk_lin.execute('grid', self.simple_gridx_3d, self.simple_gridy_3d, self.simple_gridz_3d)
         self.assertTrue(np.allclose(z_func, z_lin))
         self.assertTrue(np.allclose(ss_func, ss_lin))
+
+
+    def test_geometric_code(self):
+        # Test great_circle_distance and euclid3_to_great_circle against each other:
+        lon_ref = [0.0, 175.0, 61.234, 267.5]
+        lat_ref = [0.0, -7.5,  77.3,   -23.5]
+        for i in range(len(lon_ref)):
+            lon, lat = np.meshgrid(np.linspace(0, 360.0, 20),
+                                   np.linspace(-90.0, 90.0, 20))
+            dx = np.cos(np.pi/180.0*lon)*np.cos(np.pi/180.0*lat)- \
+                 np.cos(np.pi/180.0*lon_ref[i])*np.cos(np.pi/180.0*lat_ref[i])
+            dy = np.sin(np.pi/180.0*lon)*np.cos(np.pi/180.0*lat)- \
+                 np.sin(np.pi/180.0*lon_ref[i])*np.cos(np.pi/180.0*lat_ref[i])
+            dz = np.sin(np.pi/180.0*lat) - np.sin(np.pi/180.0*lat_ref[i])
+        
+            diff = np.abs(core.great_circle_distance(lon_ref[i], lat_ref[i], lon, lat) \
+                          -core.euclid3_to_great_circle(np.sqrt(dx**2+dy**2+dz**2)))
+            self.assertTrue(np.all(diff < 1e-3))
+    
+    def test_ok_geometric(self):
+        # Generate random data:
+        np.random.seed(89239413)
+        lon = 360.0*np.random.rand(50, 1)
+        lat = 180.0*np.random.rand(50, 1) - 90.0
+        z = np.random.rand(50, 1)
+        #data = np.concatenate((lon, lat, z), 1)
+        
+        # Generate grid:
+        grid_lon = 360.0*np.random.rand(120, 1)
+        grid_lat = 180.0*np.random.rand(120, 1) - 90.0
+        
+        # Create ordinary kriging object:
+        OK = OrdinaryKriging(lon, lat, z, variogram_model='linear', verbose=False,
+                             enable_plotting=False, coordinates_type='geographic')
+        
+        # Execute on grid:
+        z, ss = OK.execute('grid', grid_lon, grid_lat)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pykrige/test.py
+++ b/pykrige/test.py
@@ -1404,10 +1404,8 @@ class TestPyKrige(unittest.TestCase):
             dy = np.sin(np.pi/180.0*lon)*np.cos(np.pi/180.0*lat)- \
                  np.sin(np.pi/180.0*lon_ref[i])*np.cos(np.pi/180.0*lat_ref[i])
             dz = np.sin(np.pi/180.0*lat) - np.sin(np.pi/180.0*lat_ref[i])
-        
-            diff = np.abs(core.great_circle_distance(lon_ref[i], lat_ref[i], lon, lat) \
-                          -core.euclid3_to_great_circle(np.sqrt(dx**2+dy**2+dz**2)))
-            self.assertTrue(np.all(diff < 1e-3))
+            np.testing.assert_allclose(core.great_circle_distance(lon_ref[i], lat_ref[i], lon, lat),
+                core.euclid3_to_great_circle(np.sqrt(dx**2+dy**2+dz**2)), rtol=1e-5)
     
     def test_ok_geometric(self):
         # Generate random data:

--- a/pykrige/uk.py
+++ b/pykrige/uk.py
@@ -284,7 +284,8 @@ class UniversalKriging:
         self.lags, self.semivariance, self.variogram_model_parameters = \
             core.initialize_variogram_model(self.X_ADJUSTED, self.Y_ADJUSTED, self.Z,
                                             self.variogram_model, variogram_parameters,
-                                            self.variogram_function, nlags, weight)
+                                            self.variogram_function, nlags, weight,
+                                            'euclidean')
         if self.verbose:
             if self.variogram_model == 'linear':
                 print("Using '%s' Variogram Model" % 'linear')
@@ -309,7 +310,8 @@ class UniversalKriging:
             print("Calculating statistics on variogram model fit...")
         self.delta, self.sigma, self.epsilon = core.find_statistics(self.X_ADJUSTED, self.Y_ADJUSTED,
                                                                     self.Z, self.variogram_function,
-                                                                    self.variogram_model_parameters)
+                                                                    self.variogram_model_parameters,
+                                                                    'euclidean')
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)
         self.cR = core.calc_cR(self.Q2, self.sigma)
@@ -531,7 +533,8 @@ class UniversalKriging:
         self.lags, self.semivariance, self.variogram_model_parameters = \
             core.initialize_variogram_model(self.X_ADJUSTED, self.Y_ADJUSTED, self.Z,
                                             self.variogram_model, variogram_parameters,
-                                            self.variogram_function, nlags, weight)
+                                            self.variogram_function, nlags, weight,
+                                            'euclidean')
         if self.verbose:
             if self.variogram_model == 'linear':
                 print("Using '%s' Variogram Model" % 'linear')
@@ -556,7 +559,8 @@ class UniversalKriging:
             print("Calculating statistics on variogram model fit...")
         self.delta, self.sigma, self.epsilon = core.find_statistics(self.X_ADJUSTED, self.Y_ADJUSTED,
                                                                     self.Z, self.variogram_function,
-                                                                    self.variogram_model_parameters)
+                                                                    self.variogram_model_parameters,
+                                                                    'euclidean')
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)
         self.cR = core.calc_cR(self.Q2, self.sigma)

--- a/setup.py
+++ b/setup.py
@@ -90,24 +90,16 @@ def run_setup(with_cython):
                                 extra_link_args=['-O2', '-march=core2', '-mtune=corei7'])
         else:
             compile_args = {}
+        
+        ext_modules = [Extension("pykrige.lib.cok", ["pykrige/lib/cok.pyx"], **compile_args),
+                       Extension("pykrige.lib.variogram_models", ["pykrige/lib/variogram_models.pyx"], **compile_args)]
+        
         # Transfered python 3 switch here. On python 3 machines, will use lapack_py3.pyx
         # instead of lapack.pyx to build .lib.lapack
         if sys.version_info[0] == 3:
-            ext_modules = [Extension("pykrige.lib.cok", ["pykrige/lib/cok.pyx"],
-                                     **compile_args),
-                           Extension("pykrige.lib.lapack", 
-                                     ["pykrige/lib/lapack_py3.pyx"], **compile_args),
-                           Extension("pykrige.lib.variogram_models",
-                                     ["pykrige/lib/variogram_models.pyx"],
-                                     **compile_args)]
+            ext_modules += [Extension("pykrige.lib.lapack", ["pykrige/lib/lapack_py3.pyx"], **compile_args)]
         else:
-            ext_modules = [Extension("pykrige.lib.cok", ["pykrige/lib/cok.pyx"],
-                                     **compile_args),
-                           Extension("pykrige.lib.lapack", ["pykrige/lib/lapack.pyx"],
-                                     **compile_args),
-                           Extension("pykrige.lib.variogram_models",
-                                     ["pykrige/lib/variogram_models.pyx"],
-                                     **compile_args)]
+            ext_modules += [Extension("pykrige.lib.lapack", ["pykrige/lib/lapack.pyx"], **compile_args)]
 
         class TryBuildExt(build_ext):
             def build_extensions(self):


### PR DESCRIPTION
Added support for spherical coordinates (standard geographic longitude/latitude coordinate system) to ordinary kriging. Depending on choice of **coordinates_type** in the respective function, coordinates will be interpreted as either planar 2d coordinates or longitude/latitude coordinates (x being mapped to longitude and y to latitude). Thoughts on the interface?

Also merged latest master branch commits.
