### PR TITLE
Benchmark scripts

### DIFF
--- a/benchmarks/kriging_benchmarks.py
+++ b/benchmarks/kriging_benchmarks.py
@@ -16,27 +16,27 @@ def make_benchark(n_train, n_test, n_dim=2):
 
     Parameters
     ----------
-    n_train: int
+    n_train : int
       number of points in the training set
-    n_test: int
+    n_test : int
       number of points in the test set
-    n_dim: int
+    n_dim : int
       number of dimensions (default=2)
 
     Returns
     -------
-    res: dict
+    res : dict
       a dictionary with the timing results
     """
-    x_train = np.random.rand(n_train, n_dim)
+    X_train = np.random.rand(n_train, n_dim)
     y_train = np.random.rand(n_train)
-    x_test = np.random.rand(n_test, n_dim)
+    X_test = np.random.rand(n_test, n_dim)
 
     res = {}
 
     for variogram_model in VARIOGRAM_MODELS:
         tic = time()
-        OK = OrdinaryKriging(x_train[:, 0], x_train[:, 1], y_train,
+        OK = OrdinaryKriging(X_train[:, 0], X_train[:, 1], y_train,
                              variogram_model='linear',
                              verbose=False, enable_plotting=False)
         res['t_train_{}'.format(variogram_model)] = time() - tic
@@ -49,7 +49,7 @@ def make_benchark(n_train, n_test, n_dim=2):
                 continue  # this is not supported
 
             tic = time()
-            OK.execute('points', x_test[:, 0], x_test[:, 1],
+            OK.execute('points', X_test[:, 0], X_test[:, 1],
                        backend=backend,
                        n_closest_points=n_closest_points)
             res['t_test_{}_{}'.format(backend, n_closest_points)] = time() - tic
@@ -62,13 +62,13 @@ def print_benchmark(n_train, n_test, n_dim, res):
 
     Parameters
     ----------
-    n_train: int
+    n_train : int
       number of points in the training set
-    n_test: int
+    n_test : int
       number of points in the test set
-    n_dim: int
+    n_dim : int
       number of dimensions (default=2)
-    res: dict
+    res : dict
       a dictionary with the timing results
     """
     print('='*80)

--- a/benchmarks/kriging_benchmarks.py
+++ b/benchmarks/kriging_benchmarks.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+
+from time import time
+
+import numpy as np
+
+from pykrige.ok import OrdinaryKriging
+np.random.seed(19999)
+
+VARIOGRAM_MODELS = ['power', 'gaussian', 'spherical',
+                            'exponential', 'linear']
+BACKENDS = ['vectorized', 'loop', 'C']
+
+N_MOVING_WINDOW = [None, 10, 50, 100]
+
+def make_benchark(n_train, n_test, n_dim=2):
+    """ Compute the benchmarks for Ordianry Kriging 
+
+    Parameters
+    ----------
+    n_train : int
+      number of points in the training set
+    n_test : int
+      number of points in the test set
+    n_dim : int
+      number of dimensions (default=2)
+
+    Returns
+    -------
+    res : dict
+      a dictionary with the timing results
+    """
+    X_train = np.random.rand(n_train, n_dim)
+    y_train = np.random.rand(n_train)
+    X_test = np.random.rand(n_test, n_dim)
+
+    res = {}
+
+    for variogram_model in VARIOGRAM_MODELS:
+        t0 = time()
+        OK = OrdinaryKriging(X_train[:, 0], X_train[:, 1], y_train,
+                             variogram_model='linear',
+                             verbose=False, enable_plotting=False)
+        res['t_train_{}'.format(variogram_model)] = time() - t0
+
+    # All the following tests are performed with the linear variogram model
+    for backend in BACKENDS:
+        for n_closest_points in N_MOVING_WINDOW:
+
+            if backend == 'vectorized' and n_closest_points is not None:
+                continue # this is not supported
+
+            t0 = time()
+            z, ss = OK.execute('points', X_test[:, 0], X_test[:, 1],
+                               backend=backend,
+                               n_closest_points=n_closest_points)
+            res['t_test_{}_{}'.format(backend, n_closest_points)] = time() - t0
+
+    return res
+
+
+def print_benchmark(n_train, n_test, n_dim, res):
+    """ Print the benchmarks
+
+    Parameters
+    ----------
+    n_train : int
+      number of points in the training set
+    n_test : int
+      number of points in the test set
+    n_dim : int
+      number of dimensions (default=2)
+    res : dict
+      a dictionary with the timing results
+    """
+    print('='*80)
+    print(' '*10, 'N_dim={}, N_train={}, N_test={}'.format(n_dim, n_train, n_test))
+    print('='*80)
+    print('\n', '# Training the model', '\n')
+    print('|'.join(['{:>11} '.format(el) for el in ['t_train (s)'] + VARIOGRAM_MODELS]))
+    print('-' * (11 + 2) * (len(VARIOGRAM_MODELS) + 1))
+    print('|'.join(['{:>11} '.format('Training')] + \
+            ['{:>11.2} '.format(el) for el in \
+                        [res['t_train_{}'.format(mod)] for mod in VARIOGRAM_MODELS]]))
+
+    print('\n', '# Predicting kriging points', '\n')
+    print('|'.join(['{:>11} '.format(el) for el in ['t_test (s)'] + BACKENDS]))
+    print('-' * (11 + 2) * (len(BACKENDS) + 1))
+
+    for n_closest_points in N_MOVING_WINDOW:
+        timing_results = [res.get('t_test_{}_{}'.format(mod, n_closest_points), '')\
+                                for mod in BACKENDS]
+        print('|'.join(['{:>11} '.format('N_nn=' + str(n_closest_points))] + \
+                ['{:>11.2} '.format(el) for el in timing_results]))
+
+
+if __name__ == '__main__':
+    n_dim = 2
+    for n_train, n_test in [(400, 1000),
+                            (400, 2000),
+                            (800, 2000)]:
+        res = make_benchark(n_train, n_test)
+        print_benchmark(n_train, n_test, n_dim, res)

--- a/benchmarks/kriging_benchmarks.py
+++ b/benchmarks/kriging_benchmarks.py
@@ -1,62 +1,58 @@
 # -*- coding: utf-8 -*-
-
 from __future__ import print_function
-
 from time import time
-
 import numpy as np
-
 from pykrige.ok import OrdinaryKriging
 np.random.seed(19999)
 
 VARIOGRAM_MODELS = ['power', 'gaussian', 'spherical',
-                            'exponential', 'linear']
+                    'exponential', 'linear']
 BACKENDS = ['vectorized', 'loop', 'C']
-
 N_MOVING_WINDOW = [None, 10, 50, 100]
+
 
 def make_benchark(n_train, n_test, n_dim=2):
     """ Compute the benchmarks for Ordianry Kriging 
 
     Parameters
     ----------
-    n_train : int
+    n_train: int
       number of points in the training set
-    n_test : int
+    n_test: int
       number of points in the test set
-    n_dim : int
+    n_dim: int
       number of dimensions (default=2)
 
     Returns
     -------
-    res : dict
+    res: dict
       a dictionary with the timing results
     """
-    X_train = np.random.rand(n_train, n_dim)
+    x_train = np.random.rand(n_train, n_dim)
     y_train = np.random.rand(n_train)
-    X_test = np.random.rand(n_test, n_dim)
+    x_test = np.random.rand(n_test, n_dim)
 
     res = {}
 
     for variogram_model in VARIOGRAM_MODELS:
-        t0 = time()
-        OK = OrdinaryKriging(X_train[:, 0], X_train[:, 1], y_train,
+        tic = time()
+        OK = OrdinaryKriging(x_train[:, 0], x_train[:, 1], y_train,
                              variogram_model='linear',
                              verbose=False, enable_plotting=False)
-        res['t_train_{}'.format(variogram_model)] = time() - t0
+        res['t_train_{}'.format(variogram_model)] = time() - tic
 
     # All the following tests are performed with the linear variogram model
     for backend in BACKENDS:
         for n_closest_points in N_MOVING_WINDOW:
 
             if backend == 'vectorized' and n_closest_points is not None:
-                continue # this is not supported
+                continue  # this is not supported
 
-            t0 = time()
-            z, ss = OK.execute('points', X_test[:, 0], X_test[:, 1],
-                               backend=backend,
-                               n_closest_points=n_closest_points)
-            res['t_test_{}_{}'.format(backend, n_closest_points)] = time() - t0
+            tic = time()
+            OK.execute('points', x_test[:, 0], x_test[:, 1],
+                       backend=backend,
+                       n_closest_points=n_closest_points)
+            res['t_test_{}_{}'.format(backend, n_closest_points)] = time() - tic
 
     return res
 
@@ -66,40 +62,43 @@ def print_benchmark(n_train, n_test, n_dim, res):
 
     Parameters
     ----------
-    n_train : int
+    n_train: int
       number of points in the training set
-    n_test : int
+    n_test: int
       number of points in the test set
-    n_dim : int
+    n_dim: int
       number of dimensions (default=2)
-    res : dict
+    res: dict
       a dictionary with the timing results
     """
     print('='*80)
-    print(' '*10, 'N_dim={}, N_train={}, N_test={}'.format(n_dim, n_train, n_test))
+    print(' '*10, 'N_dim={}, N_train={}, N_test={}'.format(n_dim,
+                                                           n_train, n_test))
     print('='*80)
     print('\n', '# Training the model', '\n')
-    print('|'.join(['{:>11} '.format(el) for el in ['t_train (s)'] + VARIOGRAM_MODELS]))
+    print('|'.join(['{:>11} '.format(el) for el in ['t_train (s)'] +
+                    VARIOGRAM_MODELS]))
     print('-' * (11 + 2) * (len(VARIOGRAM_MODELS) + 1))
-    print('|'.join(['{:>11} '.format('Training')] + \
-            ['{:>11.2} '.format(el) for el in \
-                        [res['t_train_{}'.format(mod)] for mod in VARIOGRAM_MODELS]]))
+    print('|'.join(['{:>11} '.format('Training')] +
+                   ['{:>11.2} '.format(el) for el in
+                    [res['t_train_{}'.format(mod)]
+                     for mod in VARIOGRAM_MODELS]]))
 
     print('\n', '# Predicting kriging points', '\n')
     print('|'.join(['{:>11} '.format(el) for el in ['t_test (s)'] + BACKENDS]))
     print('-' * (11 + 2) * (len(BACKENDS) + 1))
 
     for n_closest_points in N_MOVING_WINDOW:
-        timing_results = [res.get('t_test_{}_{}'.format(mod, n_closest_points), '')\
-                                for mod in BACKENDS]
-        print('|'.join(['{:>11} '.format('N_nn=' + str(n_closest_points))] + \
-                ['{:>11.2} '.format(el) for el in timing_results]))
+        timing_results = [res.get(
+            't_test_{}_{}'.format(mod, n_closest_points), '')
+                          for mod in BACKENDS]
+        print('|'.join(['{:>11} '.format('N_nn=' + str(n_closest_points))] +
+                       ['{:>11.2} '.format(el) for el in timing_results]))
 
 
 if __name__ == '__main__':
-    n_dim = 2
-    for n_train, n_test in [(400, 1000),
-                            (400, 2000),
-                            (800, 2000)]:
-        res = make_benchark(n_train, n_test)
-        print_benchmark(n_train, n_test, n_dim, res)
+    for no_train, no_test in [(400, 1000),
+                              (400, 2000),
+                              (800, 2000)]:
+        results = make_benchark(no_train, no_test)
+        print_benchmark(no_train, no_test, 2, results)


### PR DESCRIPTION
This PR adds a quick benchmark script (for now for ordinary kriging) that could help with the optimization (for instance in issue #35 ).

The code is not so clean but it's mostly string formatting and this is not part of the core libary. An example of the output can be found below,
```
(krige-env) rth@byzance benchmarks % python kriging_benchmarks.py                  
================================================================================
           N_dim=2, N_train=400, N_test=1000
================================================================================

 # Training the model 

t_train (s) |      power |   gaussian |  spherical |exponential |     linear 
------------------------------------------------------------------------------
   Training |      0.031 |      0.022 |      0.027 |      0.028 |      0.024 

 # Predicting kriging points 

 t_test (s) | vectorized |       loop |          C 
----------------------------------------------------
  N_nn=None |      0.049 |       0.09 |      0.045 
    N_nn=10 |            |       0.12 |     0.0098 
    N_nn=50 |            |       0.24 |      0.042 
   N_nn=100 |            |       0.35 |       0.11 
================================================================================
           N_dim=2, N_train=400, N_test=2000
================================================================================

 # Training the model 

t_train (s) |      power |   gaussian |  spherical |exponential |     linear 
------------------------------------------------------------------------------
   Training |       0.02 |      0.021 |      0.021 |       0.02 |       0.02 

 # Predicting kriging points 

 t_test (s) | vectorized |       loop |          C 
----------------------------------------------------
  N_nn=None |      0.078 |       0.15 |      0.075 
    N_nn=10 |            |       0.23 |      0.015 
    N_nn=50 |            |       0.36 |      0.081 
   N_nn=100 |            |       0.64 |       0.22 
================================================================================
           N_dim=2, N_train=800, N_test=2000
================================================================================

 # Training the model 

t_train (s) |      power |   gaussian |  spherical |exponential |     linear 
------------------------------------------------------------------------------
   Training |      0.077 |      0.079 |      0.079 |      0.078 |      0.078 

 # Predicting kriging points 

 t_test (s) | vectorized |       loop |          C 
----------------------------------------------------
  N_nn=None |       0.22 |       0.64 |       0.54 
    N_nn=10 |            |       0.24 |      0.025 
    N_nn=50 |            |       0.39 |      0.097 
   N_nn=100 |            |       0.75 |       0.27
```

**Update**: the `N_nn` variable refers to the number of points in the moving window.