### PR TITLE
Refactor statistics calculations

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,8 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - "conda create -q -n _krige-env python=%PYTHON_VERSION% numpy scipy nose matplotlib cython scikit-learn"
-  - activate _krige-env
+  - "conda create -q -n krige-env python=%PYTHON_VERSION% numpy scipy nose matplotlib cython scikit-learn"
+  - activate krige-env
   - pip install coverage
 
   - dir 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,8 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - "conda create -q -n krige-env python=%PYTHON_VERSION% numpy scipy nose matplotlib cython scikit-learn"
-  - activate krige-env
+  - "conda create -q -n _krige-env python=%PYTHON_VERSION% numpy scipy nose matplotlib cython scikit-learn"
+  - activate _krige-env
   - pip install coverage
 
   - dir 

--- a/pykrige/core.py
+++ b/pykrige/core.py
@@ -30,7 +30,7 @@ Functions:
                                variogram_function, weight):
         Returns variogram model parameters that minimize the RMSE between the
         specified variogram function and the actual calculated variogram points.
-    krige(x, y, z, coords, variogram_function, variogram_model_parameters):
+    _krige(x, y, z, coords, variogram_function, variogram_model_parameters):
         Function that solves the ordinary kriging system for a single specified
         point. Returns Z value and sigma squared for the specified coordinates.
     krige_3d(x, y, z, vals, coords, variogram_function,
@@ -38,7 +38,7 @@ Functions:
         Function that solves the ordinary kriging system for a single specified
         point. Returns the interpolated value and sigma squared for the
         specified coordinates.
-    find_statistics(x, y, z, variogram_funtion, variogram_model_parameters):
+    _find_statistics(x, y, z, variogram_funtion, variogram_model_parameters):
         Returns the delta, sigma, and epsilon values for the variogram fit.
     calcQ1(epsilon):
         Returns the Q1 statistic for the variogram fit (see Kitanidis).
@@ -63,7 +63,7 @@ Copyright (c) 2015-2017 Benjamin S. Murphy
 """
 
 import numpy as np
-from scipy.spatial.distance import pdist
+from scipy.spatial.distance import pdist, squareform, cdist
 from scipy.optimize import least_squares
 
 
@@ -607,124 +607,83 @@ def _calculate_variogram_model(lags, semivariance, variogram_model,
     return res.x
 
 
-def krige(x, y, z, coords, variogram_function, variogram_model_parameters, coordinates_type):
-        """Sets up and solves the kriging matrix for the given coordinate pair.
-        This function is now only used for the statistics calculations."""
+def _krige(X, y, coords, variogram_function,
+           variogram_model_parameters, coordinates_type):
+    """Sets up and solves the kriging matrix for the given coordinate pair.
+    This function is now only used for the statistics calculations."""
 
-        zero_index = None
-        zero_value = False
+    zero_index = None
+    zero_value = False
 
-        x1, x2 = np.meshgrid(x, x, sparse=True)
-        y1, y2 = np.meshgrid(y, y, sparse=True)
+    # calculate distance between points... need a square distance matrix
+    # of inter-measurement-point distances and a vector of distances between
+    # measurement points (X) and the kriging point (coords)
+    if coordinates_type == 'euclidean':
+        d = squareform(pdist(X, metric='euclidean'))
+        bd = np.squeeze(cdist(X, coords[None, :], metric='euclidean'))
 
-        if coordinates_type == 'euclidean':
-            d = np.sqrt((x1 - x2)**2 + (y1 - y2)**2)
-            bd = np.sqrt((x - coords[0])**2 + (y - coords[1])**2)
-        elif coordinates_type == 'geographic':
-            d = great_circle_distance(x1, y1, x2, y2)
-            bd = great_circle_distance(x, y, coords[0]*np.ones(x.shape),
-                                       coords[1]*np.ones(y.shape))
-        if np.any(np.absolute(bd) <= 1e-10):
-            zero_value = True
-            zero_index = np.where(bd <= 1e-10)[0][0]
+    # geographic coordinate distances still calculated in the old way...
+    # assume X[:, 0] ('x') => lon, X[:, 1] ('y') => lat
+    # also assume problem is 2D; check done earlier in initializing variogram
+    elif coordinates_type == 'geographic':
+        x1, x2 = np.meshgrid(X[:, 0], X[:, 0], sparse=True)
+        y1, y2 = np.meshgrid(X[:, 1], X[:, 1], sparse=True)
+        d = great_circle_distance(x1, y1, x2, y2)
+        bd = great_circle_distance(X[:, 0], X[:, 1],
+                                   coords[0] * np.ones(X.shape[0]),
+                                   coords[1] * np.ones(X.shape[0]))
 
-        n = x.shape[0]
-        a = np.zeros((n+1, n+1))
-        a[:n, :n] = - variogram_function(variogram_model_parameters, d)
-        np.fill_diagonal(a, 0.0)
-        a[n, :] = 1.0
-        a[:, n] = 1.0
-        a[n, n] = 0.0
+    # this check is done when initializing variogram, but kept here anyways...
+    else:
+        raise ValueError("Specified coordinate type '%s' "
+                         "is not supported." % coordinates_type)
 
-        b = np.zeros((n+1, 1))
-        b[:n, 0] = - variogram_function(variogram_model_parameters, bd)
-        if zero_value:
-            b[zero_index, 0] = 0.0
-        b[n, 0] = 1.0
+    # check if kriging point overlaps with measurement point
+    if np.any(np.absolute(bd) <= 1e-10):
+        zero_value = True
+        zero_index = np.where(bd <= 1e-10)[0][0]
 
-        x_ = np.linalg.solve(a, b)
-        zinterp = np.sum(x_[:n, 0] * z)
-        sigmasq = np.sum(x_[:, 0] * -b[:, 0])
+    # set up kriging matrix
+    n = X.shape[0]
+    a = np.zeros((n+1, n+1))
+    a[:n, :n] = - variogram_function(variogram_model_parameters, d)
+    np.fill_diagonal(a, 0.0)
+    a[n, :] = 1.0
+    a[:, n] = 1.0
+    a[n, n] = 0.0
 
-        return zinterp, sigmasq
+    # set up RHS
+    b = np.zeros((n+1, 1))
+    b[:n, 0] = - variogram_function(variogram_model_parameters, bd)
+    if zero_value:
+        b[zero_index, 0] = 0.0
+    b[n, 0] = 1.0
 
+    # solve
+    res = np.linalg.solve(a, b)
+    zinterp = np.sum(res[:n, 0] * y)
+    sigmasq = np.sum(res[:, 0] * -b[:, 0])
 
-def krige_3d(x, y, z, vals, coords, variogram_function, variogram_model_parameters):
-        """Sets up and solves the kriging matrix for the given coordinate pair.
-        This function is now only used for the statistics calculations."""
-
-        zero_index = None
-        zero_value = False
-
-        x1, x2 = np.meshgrid(x, x, sparse=True)
-        y1, y2 = np.meshgrid(y, y, sparse=True)
-        z1, z2 = np.meshgrid(z, z, sparse=True)
-        d = np.sqrt((x1 - x2)**2 + (y1 - y2)**2 + (z1 - z2)**2)
-        bd = np.sqrt((x - coords[0])**2 + (y - coords[1])**2 + (z - coords[2])**2)
-        if np.any(np.absolute(bd) <= 1e-10):
-            zero_value = True
-            zero_index = np.where(bd <= 1e-10)[0][0]
-
-        n = x.shape[0]
-        a = np.zeros((n+1, n+1))
-        a[:n, :n] = - variogram_function(variogram_model_parameters, d)
-        np.fill_diagonal(a, 0.0)
-        a[n, :] = 1.0
-        a[:, n] = 1.0
-        a[n, n] = 0.0
-
-        b = np.zeros((n+1, 1))
-        b[:n, 0] = - variogram_function(variogram_model_parameters, bd)
-        if zero_value:
-            b[zero_index, 0] = 0.0
-        b[n, 0] = 1.0
-
-        x_ = np.linalg.solve(a, b)
-        zinterp = np.sum(x_[:n, 0] * vals)
-        sigmasq = np.sum(x_[:, 0] * -b[:, 0])
-
-        return zinterp, sigmasq
+    return zinterp, sigmasq
 
 
-def find_statistics(x, y, z, variogram_function, variogram_model_parameters, coordinates_type):
+def _find_statistics(X, y, variogram_function,
+                     variogram_model_parameters, coordinates_type):
     """Calculates variogram fit statistics."""
 
-    delta = np.zeros(z.shape)
-    sigma = np.zeros(z.shape)
+    delta = np.zeros(y.shape)
+    sigma = np.zeros(y.shape)
 
-    for n in range(z.shape[0]):
-        if n == 0:
-            delta[n] = 0.0
-            sigma[n] = 0.0
+    for i in range(y.shape[0]):
+        if i == 0:
+            delta[i] = 0.0
+            sigma[i] = 0.0
         else:
-            z_, ss_ = krige(x[:n], y[:n], z[:n], (x[n], y[n]), variogram_function,
-                            variogram_model_parameters, coordinates_type)
-            d = z[n] - z_
-            delta[n] = d
-            sigma[n] = np.sqrt(ss_)
-
-    delta = delta[1:]
-    sigma = sigma[1:]
-    epsilon = delta/sigma
-
-    return delta, sigma, epsilon
-
-
-def find_statistics_3d(x, y, z, vals, variogram_function, variogram_model_parameters):
-    """Calculates variogram fit statistics for 3D problems."""
-
-    delta = np.zeros(vals.shape)
-    sigma = np.zeros(vals.shape)
-
-    for n in range(z.shape[0]):
-        if n == 0:
-            delta[n] = 0.0
-            sigma[n] = 0.0
-        else:
-            val_, ss_ = krige_3d(x[:n], y[:n], z[:n], vals[:n], (x[n], y[n], z[n]),
-                               variogram_function, variogram_model_parameters)
-            delta[n] = vals[n] - val_
-            sigma[n] = np.sqrt(ss_)
+            k, ss = _krige(X[:i, :], y[:i], X[i, :], variogram_function,
+                           variogram_model_parameters, coordinates_type)
+            d = y[i] - k
+            delta[i] = d
+            sigma[i] = np.sqrt(ss)
 
     delta = delta[1:]
     sigma = sigma[1:]

--- a/pykrige/core.py
+++ b/pykrige/core.py
@@ -30,16 +30,15 @@ Functions:
                                variogram_function, weight):
         Returns variogram model parameters that minimize the RMSE between the
         specified variogram function and the actual calculated variogram points.
-    _krige(x, y, z, coords, variogram_function, variogram_model_parameters):
+    _krige(X, y, coords, variogram_function, variogram_model_parameters,
+           coordinates_type):
         Function that solves the ordinary kriging system for a single specified
         point. Returns Z value and sigma squared for the specified coordinates.
-    krige_3d(x, y, z, vals, coords, variogram_function,
-             variogram_model_parameters):
-        Function that solves the ordinary kriging system for a single specified
-        point. Returns the interpolated value and sigma squared for the
-        specified coordinates.
-    _find_statistics(x, y, z, variogram_funtion, variogram_model_parameters):
+        Used in statistics calculation.
+    _find_statistics(X, y, variogram_funtion, variogram_model_parameters,
+                     coordinates_type):
         Returns the delta, sigma, and epsilon values for the variogram fit.
+        These arrays are used for statistics calculations.
     calcQ1(epsilon):
         Returns the Q1 statistic for the variogram fit (see Kitanidis).
     calcQ2(epsilon):
@@ -612,7 +611,31 @@ def _calculate_variogram_model(lags, semivariance, variogram_model,
 def _krige(X, y, coords, variogram_function,
            variogram_model_parameters, coordinates_type):
     """Sets up and solves the kriging matrix for the given coordinate pair.
-    This function is now only used for the statistics calculations."""
+    This function is only used for the statistics calculations.
+
+    Parameters
+    ----------
+    X: ndarray
+        float array [n_samples, n_dim], the input array of coordinates
+    y: ndarray
+        float array [n_samples], the input array of measurement values
+    coords: ndarray
+        float array [1, n_dim], point at which to evaluate the kriging system
+    variogram_function: callable
+        function that will be called to evaluate variogram model
+    variogram_model_parameters: list
+        user-specified parameters for variogram model
+    coordinates_type: str
+        type of coordinates in X array, can be 'euclidean' for standard
+        rectangular coordinates or 'geographic' if the coordinates are lat/lon
+
+    Returns
+    -------
+    zinterp: float
+        kriging estimate at the specified point
+    sigmasq: float
+        mean square error of the kriging estimate
+    """
 
     zero_index = None
     zero_value = False
@@ -671,7 +694,31 @@ def _krige(X, y, coords, variogram_function,
 
 def _find_statistics(X, y, variogram_function,
                      variogram_model_parameters, coordinates_type):
-    """Calculates variogram fit statistics."""
+    """Calculates variogram fit statistics.
+
+    Parameters
+    ----------
+    X: ndarray
+        float array [n_samples, n_dim], the input array of coordinates
+    y: ndarray
+        float array [n_samples], the input array of measurement values
+    variogram_function: callable
+        function that will be called to evaluate variogram model
+    variogram_model_parameters: list
+        user-specified parameters for variogram model
+    coordinates_type: str
+        type of coordinates in X array, can be 'euclidean' for standard
+        rectangular coordinates or 'geographic' if the coordinates are lat/lon
+
+    Returns
+    -------
+    delta: ndarray
+        residuals between observed values and kriged estimates for those values
+    sigma: ndarray
+        mean error in kriging estimates
+    epsilon: ndarray
+        residuals normalized by their mean error
+    """
 
     delta = np.zeros(y.shape)
     sigma = np.zeros(y.shape)

--- a/pykrige/ok.py
+++ b/pykrige/ok.py
@@ -30,7 +30,7 @@ import matplotlib.pyplot as plt
 from . import variogram_models
 from . import core
 from .core import _adjust_for_anisotropy, _initialize_variogram_model, \
-    _make_variogram_parameter_list
+    _make_variogram_parameter_list, _find_statistics
 import warnings
 
 
@@ -353,10 +353,12 @@ class OrdinaryKriging:
         if self.verbose:
             print("Calculating statistics on variogram model fit...")
         if enable_statistics:
-            self.delta, self.sigma, self.epsilon = core.find_statistics(self.X_ADJUSTED, self.Y_ADJUSTED,
-                                                                        self.Z, self.variogram_function,
-                                                                        self.variogram_model_parameters,
-                                                                        self.coordinates_type)
+            self.delta, self.sigma, self.epsilon = \
+                _find_statistics(np.vstack((self.X_ADJUSTED,
+                                            self.Y_ADJUSTED)).T,
+                                 self.Z, self.variogram_function,
+                                 self.variogram_model_parameters,
+                                 self.coordinates_type)
             self.Q1 = core.calcQ1(self.epsilon)
             self.Q2 = core.calcQ2(self.epsilon)
             self.cR = core.calc_cR(self.Q2, self.sigma)
@@ -442,10 +444,11 @@ class OrdinaryKriging:
 
         if self.verbose:
             print("Calculating statistics on variogram model fit...")
-        self.delta, self.sigma, self.epsilon = core.find_statistics(self.X_ADJUSTED, self.Y_ADJUSTED,
-                                                                    self.Z, self.variogram_function,
-                                                                    self.variogram_model_parameters,
-                                                                    self.coordinates_type)
+        self.delta, self.sigma, self.epsilon = \
+            _find_statistics(np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED)).T,
+                             self.Z, self.variogram_function,
+                             self.variogram_model_parameters,
+                             self.coordinates_type)
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)
         self.cR = core.calc_cR(self.Q2, self.sigma)

--- a/pykrige/ok3d.py
+++ b/pykrige/ok3d.py
@@ -28,7 +28,7 @@ import matplotlib.pyplot as plt
 from . import variogram_models
 from . import core
 from .core import _adjust_for_anisotropy, _initialize_variogram_model, \
-    _make_variogram_parameter_list
+    _make_variogram_parameter_list, _find_statistics
 import warnings
 
 
@@ -351,7 +351,8 @@ class OrdinaryKriging3D:
             else:
                 print("Using '%s' Variogram Model" % self.variogram_model)
                 print("Partial Sill:", self.variogram_model_parameters[0])
-                print("Full Sill:", self.variogram_model_parameters[0] + self.variogram_model_parameters[2])
+                print("Full Sill:", self.variogram_model_parameters[0] +
+                      self.variogram_model_parameters[2])
                 print("Range:", self.variogram_model_parameters[1])
                 print("Nugget:", self.variogram_model_parameters[2], '\n')
         if self.enable_plotting:
@@ -359,10 +360,12 @@ class OrdinaryKriging3D:
 
         if self.verbose:
             print("Calculating statistics on variogram model fit...")
-        self.delta, self.sigma, self.epsilon = core.find_statistics_3d(self.X_ADJUSTED, self.Y_ADJUSTED,
-                                                                       self.Z_ADJUSTED, self.VALUES,
-                                                                       self.variogram_function,
-                                                                       self.variogram_model_parameters)
+        self.delta, self.sigma, self.epsilon = \
+            _find_statistics(np.vstack((self.X_ADJUSTED,
+                                        self.Y_ADJUSTED,
+                                        self.Z_ADJUSTED)).T,
+                             self.VALUES,  self.variogram_function,
+                             self.variogram_model_parameters, 'euclidean')
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)
         self.cR = core.calc_cR(self.Q2, self.sigma)
@@ -441,10 +444,12 @@ class OrdinaryKriging3D:
 
         if self.verbose:
             print("Calculating statistics on variogram model fit...")
-        self.delta, self.sigma, self.epsilon = core.find_statistics_3d(self.X_ADJUSTED, self.Y_ADJUSTED,
-                                                                       self.Z_ADJUSTED, self.VALUES,
-                                                                       self.variogram_function,
-                                                                       self.variogram_model_parameters)
+        self.delta, self.sigma, self.epsilon = \
+            _find_statistics(np.vstack((self.X_ADJUSTED,
+                                        self.Y_ADJUSTED,
+                                        self.Z_ADJUSTED)).T,
+                             self.VALUES, self.variogram_function,
+                             self.variogram_model_parameters, 'euclidean')
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)
         self.cR = core.calc_cR(self.Q2, self.sigma)

--- a/pykrige/rk.py
+++ b/pykrige/rk.py
@@ -20,7 +20,7 @@ threed_krige = ('ordinary3d', 'universal3d')
 
 def validate_method(method):
     if method not in krige_methods.keys():
-        raise ValueError('Kirging method must be '
+        raise ValueError('Kriging method must be '
                          'one of {}'.format(krige_methods.keys()))
 
 
@@ -85,12 +85,12 @@ class Krige(RegressorMixin, BaseEstimator):
     def _dimensionality_check(self, x, ext=''):
         if self.method in ('ordinary', 'universal'):
             if x.shape[1] != 2:
-                raise ValueError('2d _krige can use only 2d points')
+                raise ValueError('2d krige can use only 2d points')
             else:
                 return {'x' + ext: x[:, 0], 'y' + ext: x[:, 1]}
         if self.method in ('ordinary3d', 'universal3d'):
             if x.shape[1] != 3:
-                raise ValueError('3d _krige can use only 3d points')
+                raise ValueError('3d krige can use only 3d points')
             else:
                 return {'x' + ext: x[:, 0],
                         'y' + ext: x[:, 1],

--- a/pykrige/rk.py
+++ b/pykrige/rk.py
@@ -85,12 +85,12 @@ class Krige(RegressorMixin, BaseEstimator):
     def _dimensionality_check(self, x, ext=''):
         if self.method in ('ordinary', 'universal'):
             if x.shape[1] != 2:
-                raise ValueError('2d krige can use only 2d points')
+                raise ValueError('2d _krige can use only 2d points')
             else:
                 return {'x' + ext: x[:, 0], 'y' + ext: x[:, 1]}
         if self.method in ('ordinary3d', 'universal3d'):
             if x.shape[1] != 3:
-                raise ValueError('3d krige can use only 3d points')
+                raise ValueError('3d _krige can use only 3d points')
             else:
                 return {'x' + ext: x[:, 0],
                         'y' + ext: x[:, 1],

--- a/pykrige/test.py
+++ b/pykrige/test.py
@@ -282,15 +282,17 @@ class TestPyKrige(unittest.TestCase):
         # Example 3.2 from Kitanidis
         data = np.array([[9.7, 47.6, 1.22],
                          [43.8, 24.6, 2.822]])
-        z, ss = core.krige(data[:, 0], data[:, 1], data[:, 2], (18.8, 67.9),
-                           variogram_models.linear_variogram_model, [0.006, 0.1],
-                           'euclidean')
+        z, ss = core._krige(np.vstack((data[:, 0], data[:, 1])).T, data[:, 2],
+                            np.array([18.8, 67.9]),
+                            variogram_models.linear_variogram_model,
+                            [0.006, 0.1], 'euclidean')
         self.assertAlmostEqual(z, 1.6364, 4)
         self.assertAlmostEqual(ss, 0.4201, 4)
 
-        z, ss = core.krige(data[:, 0], data[:, 1], data[:, 2], (43.8, 24.6),
-                           variogram_models.linear_variogram_model, [0.006, 0.1],
-                           'euclidean')
+        z, ss = core._krige(np.vstack((data[:, 0], data[:, 1])).T, data[:, 2],
+                            np.array([43.8, 24.6]),
+                            variogram_models.linear_variogram_model,
+                            [0.006, 0.1], 'euclidean')
         self.assertAlmostEqual(z, 2.822, 3)
         self.assertAlmostEqual(ss, 0.0, 3)
 
@@ -299,13 +301,17 @@ class TestPyKrige(unittest.TestCase):
         # Adapted from example 3.2 from Kitanidis
         data = np.array([[9.7, 47.6, 1.0, 1.22],
                          [43.8, 24.6, 1.0, 2.822]])
-        z, ss = core.krige_3d(data[:, 0], data[:, 1], data[:, 2], data[:, 3], (18.8, 67.9, 1.0),
-                              variogram_models.linear_variogram_model, [0.006, 0.1])
+        z, ss = core._krige(np.vstack((data[:, 0], data[:, 1], data[:, 2])).T,
+                            data[:, 3], np.array([18.8, 67.9, 1.0]),
+                            variogram_models.linear_variogram_model,
+                            [0.006, 0.1], 'euclidean')
         self.assertAlmostEqual(z, 1.6364, 4)
         self.assertAlmostEqual(ss, 0.4201, 4)
 
-        z, ss = core.krige_3d(data[:, 0], data[:, 1], data[:, 2], data[:, 3], (43.8, 24.6, 1.0),
-                              variogram_models.linear_variogram_model, [0.006, 0.1])
+        z, ss = core._krige(np.vstack((data[:, 0], data[:, 1], data[:, 2])).T,
+                            data[:, 3], np.array([43.8, 24.6, 1.0]),
+                            variogram_models.linear_variogram_model,
+                            [0.006, 0.1], 'euclidean')
         self.assertAlmostEqual(z, 2.822, 3)
         self.assertAlmostEqual(ss, 0.0, 3)
 
@@ -817,7 +823,8 @@ class TestPyKrige(unittest.TestCase):
         ok = OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2],
                              variogram_model='linear',
                              variogram_parameters=[1.0, 1.0])
-        z, ss = ok.execute('grid', [1., 2., 3.], [1., 2., 3.], backend='vectorized')
+        z, ss = ok.execute('grid', [1., 2., 3.], [1., 2., 3.],
+                           backend='vectorized')
         self.assertAlmostEqual(z[0, 0], 2.0)
         self.assertAlmostEqual(ss[0, 0], 0.0)
         self.assertAlmostEqual(z[1, 1], 1.5)
@@ -826,13 +833,15 @@ class TestPyKrige(unittest.TestCase):
         self.assertAlmostEqual(ss[2, 2], 0.0)
         self.assertNotAlmostEqual(ss[0, 2], 0.0)
         self.assertNotAlmostEqual(ss[2, 0], 0.0)
-        z, ss = ok.execute('points', [1., 2., 3., 3.], [2., 1., 1., 3.], backend='vectorized')
+        z, ss = ok.execute('points', [1., 2., 3., 3.], [2., 1., 1., 3.],
+                           backend='vectorized')
         self.assertNotAlmostEqual(ss[0], 0.0)
         self.assertNotAlmostEqual(ss[1], 0.0)
         self.assertNotAlmostEqual(ss[2], 0.0)
         self.assertAlmostEqual(z[3], 1.0)
         self.assertAlmostEqual(ss[3], 0.0)
-        z, ss = ok.execute('grid', np.arange(0., 4., 0.1), np.arange(0., 4., 0.1), backend='vectorized')
+        z, ss = ok.execute('grid', np.arange(0., 4., 0.1),
+                           np.arange(0., 4., 0.1), backend='vectorized')
         self.assertAlmostEqual(z[10, 10], 2.)
         self.assertAlmostEqual(ss[10, 10], 0.)
         self.assertAlmostEqual(z[20, 20], 1.5)
@@ -847,13 +856,16 @@ class TestPyKrige(unittest.TestCase):
         self.assertNotAlmostEqual(ss[10, 20], 0.0)
         self.assertNotAlmostEqual(ss[30, 20], 0.0)
         self.assertNotAlmostEqual(ss[20, 30], 0.0)
-        z, ss = ok.execute('grid', np.arange(0., 3.1, 0.1), np.arange(2.1, 3.1, 0.1), backend='vectorized')
+        z, ss = ok.execute('grid', np.arange(0., 3.1, 0.1),
+                           np.arange(2.1, 3.1, 0.1), backend='vectorized')
         self.assertTrue(np.any(ss <= 1e-15))
         self.assertFalse(np.any(ss[:9, :30] <= 1e-15))
         self.assertFalse(np.allclose(z[:9, :30], 0.))
-        z, ss = ok.execute('grid', np.arange(0., 1.9, 0.1), np.arange(2.1, 3.1, 0.1), backend='vectorized')
+        z, ss = ok.execute('grid', np.arange(0., 1.9, 0.1),
+                           np.arange(2.1, 3.1, 0.1), backend='vectorized')
         self.assertFalse(np.any(ss <= 1e-15))
-        z, ss = ok.execute('masked', np.arange(2.5, 3.5, 0.1), np.arange(2.5, 3.5, 0.25), backend='vectorized',
+        z, ss = ok.execute('masked', np.arange(2.5, 3.5, 0.1),
+                           np.arange(2.5, 3.5, 0.25), backend='vectorized',
                            mask=np.asarray(np.meshgrid(np.arange(2.5, 3.5, 0.1), np.arange(2.5, 3.5, 0.25))[0] == 0.))
         self.assertTrue(ss[2, 5] <= 1e-15)
         self.assertFalse(np.allclose(ss, 0.))
@@ -867,13 +879,15 @@ class TestPyKrige(unittest.TestCase):
         self.assertAlmostEqual(ss[2, 2], 0.0)
         self.assertNotAlmostEqual(ss[0, 2], 0.0)
         self.assertNotAlmostEqual(ss[2, 0], 0.0)
-        z, ss = ok.execute('points', [1., 2., 3., 3.], [2., 1., 1., 3.], backend='loop')
+        z, ss = ok.execute('points', [1., 2., 3., 3.], [2., 1., 1., 3.],
+                           backend='loop')
         self.assertNotAlmostEqual(ss[0], 0.0)
         self.assertNotAlmostEqual(ss[1], 0.0)
         self.assertNotAlmostEqual(ss[2], 0.0)
         self.assertAlmostEqual(z[3], 1.0)
         self.assertAlmostEqual(ss[3], 0.0)
-        z, ss = ok.execute('grid', np.arange(0., 4., 0.1), np.arange(0., 4., 0.1), backend='loop')
+        z, ss = ok.execute('grid', np.arange(0., 4., 0.1),
+                           np.arange(0., 4., 0.1), backend='loop')
         self.assertAlmostEqual(z[10, 10], 2.)
         self.assertAlmostEqual(ss[10, 10], 0.)
         self.assertAlmostEqual(z[20, 20], 1.5)
@@ -888,19 +902,23 @@ class TestPyKrige(unittest.TestCase):
         self.assertNotAlmostEqual(ss[10, 20], 0.0)
         self.assertNotAlmostEqual(ss[30, 20], 0.0)
         self.assertNotAlmostEqual(ss[20, 30], 0.0)
-        z, ss = ok.execute('grid', np.arange(0., 3.1, 0.1), np.arange(2.1, 3.1, 0.1), backend='loop')
+        z, ss = ok.execute('grid', np.arange(0., 3.1, 0.1),
+                           np.arange(2.1, 3.1, 0.1), backend='loop')
         self.assertTrue(np.any(ss <= 1e-15))
         self.assertFalse(np.any(ss[:9, :30] <= 1e-15))
         self.assertFalse(np.allclose(z[:9, :30], 0.))
-        z, ss = ok.execute('grid', np.arange(0., 1.9, 0.1), np.arange(2.1, 3.1, 0.1), backend='loop')
+        z, ss = ok.execute('grid', np.arange(0., 1.9, 0.1),
+                           np.arange(2.1, 3.1, 0.1), backend='loop')
         self.assertFalse(np.any(ss <= 1e-15))
-        z, ss = ok.execute('masked', np.arange(2.5, 3.5, 0.1), np.arange(2.5, 3.5, 0.25), backend='loop',
+        z, ss = ok.execute('masked', np.arange(2.5, 3.5, 0.1),
+                           np.arange(2.5, 3.5, 0.25), backend='loop',
                            mask=np.asarray(np.meshgrid(np.arange(2.5, 3.5, 0.1), np.arange(2.5, 3.5, 0.25))[0] == 0.))
         self.assertTrue(ss[2, 5] <= 1e-15)
         self.assertFalse(np.allclose(ss, 0.))
 
         uk = UniversalKriging(data[:, 0], data[:, 1], data[:, 2])
-        z, ss = uk.execute('grid', [1., 2., 3.], [1., 2., 3.], backend='vectorized')
+        z, ss = uk.execute('grid', [1., 2., 3.], [1., 2., 3.],
+                           backend='vectorized')
         self.assertAlmostEqual(z[0, 0], 2.0)
         self.assertAlmostEqual(ss[0, 0], 0.0)
         self.assertAlmostEqual(z[1, 1], 1.5)
@@ -909,13 +927,15 @@ class TestPyKrige(unittest.TestCase):
         self.assertAlmostEqual(ss[2, 2], 0.0)
         self.assertNotAlmostEqual(ss[0, 2], 0.0)
         self.assertNotAlmostEqual(ss[2, 0], 0.0)
-        z, ss = uk.execute('points', [1., 2., 3., 3.], [2., 1., 1., 3.], backend='vectorized')
+        z, ss = uk.execute('points', [1., 2., 3., 3.], [2., 1., 1., 3.],
+                           backend='vectorized')
         self.assertNotAlmostEqual(ss[0], 0.0)
         self.assertNotAlmostEqual(ss[1], 0.0)
         self.assertNotAlmostEqual(ss[2], 0.0)
         self.assertAlmostEqual(z[3], 1.0)
         self.assertAlmostEqual(ss[3], 0.0)
-        z, ss = uk.execute('grid', np.arange(0., 4., 0.1), np.arange(0., 4., 0.1), backend='vectorized')
+        z, ss = uk.execute('grid', np.arange(0., 4., 0.1),
+                           np.arange(0., 4., 0.1), backend='vectorized')
         self.assertAlmostEqual(z[10, 10], 2.)
         self.assertAlmostEqual(ss[10, 10], 0.)
         self.assertAlmostEqual(z[20, 20], 1.5)
@@ -930,13 +950,16 @@ class TestPyKrige(unittest.TestCase):
         self.assertNotAlmostEqual(ss[10, 20], 0.0)
         self.assertNotAlmostEqual(ss[30, 20], 0.0)
         self.assertNotAlmostEqual(ss[20, 30], 0.0)
-        z, ss = uk.execute('grid', np.arange(0., 3.1, 0.1), np.arange(2.1, 3.1, 0.1), backend='vectorized')
+        z, ss = uk.execute('grid', np.arange(0., 3.1, 0.1),
+                           np.arange(2.1, 3.1, 0.1), backend='vectorized')
         self.assertTrue(np.any(ss <= 1e-15))
         self.assertFalse(np.any(ss[:9, :30] <= 1e-15))
         self.assertFalse(np.allclose(z[:9, :30], 0.))
-        z, ss = uk.execute('grid', np.arange(0., 1.9, 0.1), np.arange(2.1, 3.1, 0.1), backend='vectorized')
+        z, ss = uk.execute('grid', np.arange(0., 1.9, 0.1),
+                           np.arange(2.1, 3.1, 0.1), backend='vectorized')
         self.assertFalse(np.any(ss <= 1e-15))
-        z, ss = uk.execute('masked', np.arange(2.5, 3.5, 0.1), np.arange(2.5, 3.5, 0.25), backend='vectorized',
+        z, ss = uk.execute('masked', np.arange(2.5, 3.5, 0.1),
+                           np.arange(2.5, 3.5, 0.25), backend='vectorized',
                            mask=np.asarray(np.meshgrid(np.arange(2.5, 3.5, 0.1), np.arange(2.5, 3.5, 0.25))[0] == 0.))
         self.assertTrue(ss[2, 5] <= 1e-15)
         self.assertFalse(np.allclose(ss, 0.))
@@ -949,13 +972,15 @@ class TestPyKrige(unittest.TestCase):
         self.assertAlmostEqual(ss[2, 2], 0.0)
         self.assertNotAlmostEqual(ss[0, 2], 0.0)
         self.assertNotAlmostEqual(ss[2, 0], 0.0)
-        z, ss = uk.execute('points', [1., 2., 3., 3.], [2., 1., 1., 3.], backend='loop')
+        z, ss = uk.execute('points', [1., 2., 3., 3.], [2., 1., 1., 3.],
+                           backend='loop')
         self.assertNotAlmostEqual(ss[0], 0.0)
         self.assertNotAlmostEqual(ss[1], 0.0)
         self.assertNotAlmostEqual(ss[2], 0.0)
         self.assertAlmostEqual(z[3], 1.0)
         self.assertAlmostEqual(ss[3], 0.0)
-        z, ss = uk.execute('grid', np.arange(0., 4., 0.1), np.arange(0., 4., 0.1), backend='loop')
+        z, ss = uk.execute('grid', np.arange(0., 4., 0.1),
+                           np.arange(0., 4., 0.1), backend='loop')
         self.assertAlmostEqual(z[10, 10], 2.)
         self.assertAlmostEqual(ss[10, 10], 0.)
         self.assertAlmostEqual(z[20, 20], 1.5)
@@ -970,25 +995,30 @@ class TestPyKrige(unittest.TestCase):
         self.assertNotAlmostEqual(ss[10, 20], 0.0)
         self.assertNotAlmostEqual(ss[30, 20], 0.0)
         self.assertNotAlmostEqual(ss[20, 30], 0.0)
-        z, ss = uk.execute('grid', np.arange(0., 3.1, 0.1), np.arange(2.1, 3.1, 0.1), backend='loop')
+        z, ss = uk.execute('grid', np.arange(0., 3.1, 0.1),
+                           np.arange(2.1, 3.1, 0.1), backend='loop')
         self.assertTrue(np.any(ss <= 1e-15))
         self.assertFalse(np.any(ss[:9, :30] <= 1e-15))
         self.assertFalse(np.allclose(z[:9, :30], 0.))
-        z, ss = uk.execute('grid', np.arange(0., 1.9, 0.1), np.arange(2.1, 3.1, 0.1), backend='loop')
+        z, ss = uk.execute('grid', np.arange(0., 1.9, 0.1),
+                           np.arange(2.1, 3.1, 0.1), backend='loop')
         self.assertFalse(np.any(ss <= 1e-15))
-        z, ss = uk.execute('masked', np.arange(2.5, 3.5, 0.1), np.arange(2.5, 3.5, 0.25), backend='loop',
+        z, ss = uk.execute('masked', np.arange(2.5, 3.5, 0.1),
+                           np.arange(2.5, 3.5, 0.25), backend='loop',
                            mask=np.asarray(np.meshgrid(np.arange(2.5, 3.5, 0.1), np.arange(2.5, 3.5, 0.25))[0] == 0.))
         self.assertTrue(ss[2, 5] <= 1e-15)
         self.assertFalse(np.allclose(ss, 0.))
 
-        z, ss = core.krige(data[:, 0], data[:, 1], data[:, 2], (1., 1.),
-                           variogram_models.linear_variogram_model, [1.0, 1.0],
-                           'euclidean')
+        z, ss = core._krige(np.vstack((data[:, 0], data[:, 1])).T,
+                            data[:, 2], np.array([1., 1.]),
+                            variogram_models.linear_variogram_model, [1.0, 1.0],
+                            'euclidean')
         self.assertAlmostEqual(z, 2.)
         self.assertAlmostEqual(ss, 0.)
-        z, ss = core.krige(data[:, 0], data[:, 1], data[:, 2], (1., 2.),
-                           variogram_models.linear_variogram_model, [1.0, 1.0],
-                           'euclidean')
+        z, ss = core._krige(np.vstack((data[:, 0], data[:, 1])).T,
+                            data[:, 2], np.array([1., 2.]),
+                            variogram_models.linear_variogram_model, [1.0, 1.0],
+                            'euclidean')
         self.assertNotAlmostEqual(ss, 0.)
 
         data = np.zeros((50, 3))
@@ -997,32 +1027,42 @@ class TestPyKrige(unittest.TestCase):
         data[:, 1] = np.ravel(y)
         data[:, 2] = np.ravel(x) * np.ravel(y)
         ok = OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2],
-                             variogram_model='linear', variogram_parameters=[100.0, 1.0])
-        z, ss = ok.execute('grid', np.arange(0., 10., 1.), np.arange(0., 10., 2.), backend='vectorized')
+                             variogram_model='linear',
+                             variogram_parameters=[100.0, 1.0])
+        z, ss = ok.execute('grid', np.arange(0., 10., 1.),
+                           np.arange(0., 10., 2.), backend='vectorized')
         self.assertTrue(np.allclose(np.ravel(z), data[:, 2]))
         self.assertTrue(np.allclose(ss, 0.))
-        z, ss = ok.execute('grid', np.arange(0.5, 10., 1.), np.arange(0.5, 10., 2.), backend='vectorized')
+        z, ss = ok.execute('grid', np.arange(0.5, 10., 1.),
+                           np.arange(0.5, 10., 2.), backend='vectorized')
         self.assertFalse(np.allclose(np.ravel(z), data[:, 2]))
         self.assertFalse(np.allclose(ss, 0.))
-        z, ss = ok.execute('grid', np.arange(0., 10., 1.), np.arange(0., 10., 2.), backend='loop')
+        z, ss = ok.execute('grid', np.arange(0., 10., 1.),
+                           np.arange(0., 10., 2.), backend='loop')
         self.assertTrue(np.allclose(np.ravel(z), data[:, 2]))
         self.assertTrue(np.allclose(ss, 0.))
-        z, ss = ok.execute('grid', np.arange(0.5, 10., 1.), np.arange(0.5, 10., 2.), backend='loop')
+        z, ss = ok.execute('grid', np.arange(0.5, 10., 1.),
+                           np.arange(0.5, 10., 2.), backend='loop')
         self.assertFalse(np.allclose(np.ravel(z), data[:, 2]))
         self.assertFalse(np.allclose(ss, 0.))
 
         uk = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                              variogram_model='linear', variogram_parameters=[100.0, 1.0])
-        z, ss = uk.execute('grid', np.arange(0., 10., 1.), np.arange(0., 10., 2.), backend='vectorized')
+                              variogram_model='linear',
+                              variogram_parameters=[100.0, 1.0])
+        z, ss = uk.execute('grid', np.arange(0., 10., 1.),
+                           np.arange(0., 10., 2.), backend='vectorized')
         self.assertTrue(np.allclose(np.ravel(z), data[:, 2]))
         self.assertTrue(np.allclose(ss, 0.))
-        z, ss = uk.execute('grid', np.arange(0.5, 10., 1.), np.arange(0.5, 10., 2.), backend='vectorized')
+        z, ss = uk.execute('grid', np.arange(0.5, 10., 1.),
+                           np.arange(0.5, 10., 2.), backend='vectorized')
         self.assertFalse(np.allclose(np.ravel(z), data[:, 2]))
         self.assertFalse(np.allclose(ss, 0.))
-        z, ss = uk.execute('grid', np.arange(0., 10., 1.), np.arange(0., 10., 2.), backend='loop')
+        z, ss = uk.execute('grid', np.arange(0., 10., 1.),
+                           np.arange(0., 10., 2.), backend='loop')
         self.assertTrue(np.allclose(np.ravel(z), data[:, 2]))
         self.assertTrue(np.allclose(ss, 0.))
-        z, ss = uk.execute('grid', np.arange(0.5, 10., 1.), np.arange(0.5, 10., 2.), backend='loop')
+        z, ss = uk.execute('grid', np.arange(0.5, 10., 1.),
+                           np.arange(0.5, 10., 2.), backend='loop')
         self.assertFalse(np.allclose(np.ravel(z), data[:, 2]))
         self.assertFalse(np.allclose(ss, 0.))
 

--- a/pykrige/uk.py
+++ b/pykrige/uk.py
@@ -29,7 +29,7 @@ import matplotlib.pyplot as plt
 from . import variogram_models
 from . import core
 from .core import _adjust_for_anisotropy, _initialize_variogram_model, \
-    _make_variogram_parameter_list
+    _make_variogram_parameter_list, _find_statistics
 import warnings
 
 
@@ -384,10 +384,11 @@ class UniversalKriging:
 
         if self.verbose:
             print("Calculating statistics on variogram model fit...")
-        self.delta, self.sigma, self.epsilon = core.find_statistics(self.X_ADJUSTED, self.Y_ADJUSTED,
-                                                                    self.Z, self.variogram_function,
-                                                                    self.variogram_model_parameters,
-                                                                    'euclidean')
+        self.delta, self.sigma, self.epsilon = \
+            _find_statistics(np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED)).T,
+                             self.Z, self.variogram_function,
+                             self.variogram_model_parameters,
+                             'euclidean')
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)
         self.cR = core.calc_cR(self.Q2, self.sigma)
@@ -640,10 +641,11 @@ class UniversalKriging:
 
         if self.verbose:
             print("Calculating statistics on variogram model fit...")
-        self.delta, self.sigma, self.epsilon = core.find_statistics(self.X_ADJUSTED, self.Y_ADJUSTED,
-                                                                    self.Z, self.variogram_function,
-                                                                    self.variogram_model_parameters,
-                                                                    'euclidean')
+        self.delta, self.sigma, self.epsilon = \
+            _find_statistics(np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED)).T,
+                             self.Z, self.variogram_function,
+                             self.variogram_model_parameters,
+                             'euclidean')
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)
         self.cR = core.calc_cR(self.Q2, self.sigma)

--- a/pykrige/uk3d.py
+++ b/pykrige/uk3d.py
@@ -28,7 +28,7 @@ import matplotlib.pyplot as plt
 from . import variogram_models
 from . import core
 from .core import _adjust_for_anisotropy, _initialize_variogram_model, \
-    _make_variogram_parameter_list
+    _make_variogram_parameter_list, _find_statistics
 import warnings
 
 
@@ -400,10 +400,12 @@ class UniversalKriging3D:
 
         if self.verbose:
             print("Calculating statistics on variogram model fit...")
-        self.delta, self.sigma, self.epsilon = core.find_statistics_3d(self.X_ADJUSTED, self.Y_ADJUSTED,
-                                                                       self.Z_ADJUSTED, self.VALUES,
-                                                                       self.variogram_function,
-                                                                       self.variogram_model_parameters)
+        self.delta, self.sigma, self.epsilon = \
+            _find_statistics(np.vstack((self.X_ADJUSTED,
+                                        self.Y_ADJUSTED,
+                                        self.Z_ADJUSTED)).T,
+                             self.VALUES, self.variogram_function,
+                             self.variogram_model_parameters, 'euclidean')
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)
         self.cR = core.calc_cR(self.Q2, self.sigma)
@@ -523,10 +525,12 @@ class UniversalKriging3D:
 
         if self.verbose:
             print("Calculating statistics on variogram model fit...")
-        self.delta, self.sigma, self.epsilon = core.find_statistics_3d(self.X_ADJUSTED, self.Y_ADJUSTED,
-                                                                       self.Z_ADJUSTED, self.VALUES,
-                                                                       self.variogram_function,
-                                                                       self.variogram_model_parameters)
+        self.delta, self.sigma, self.epsilon = \
+            _find_statistics(np.vstack((self.X_ADJUSTED,
+                                        self.Y_ADJUSTED,
+                                        self.Z_ADJUSTED)).T,
+                             self.VALUES, self.variogram_function,
+                             self.variogram_model_parameters, 'euclidean')
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)
         self.cR = core.calc_cR(self.Q2, self.sigma)


### PR DESCRIPTION
This PR does an ND refactor of the statistics calculation routine. Here is a list of major changes:
* The ```krige``` and ```krige3d``` methods in the ```core``` module have been merged in ```_krige```.
* The ```find_statistics``` and ```find_statistics_3d``` methods in ```core``` have been merged into ```_find_statistics```.
* ```_find_statistics``` has been updated to deal with the potential for subsequent kriging points being too close together... Previously, the mean error could at times end up being basically zero (< 1e-10), which lead to problems in the statistics calculation. The should robustify the statistics calculation routine.

This address steps 3 and 4 in #31.