### PR TITLE
MNT Render the documentation online & remove Circle CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 # command to run tests
 script: 
     - cd ./PyKrige/pykrige/
-    - nosetests ./test.py --with-coverage --cover-package=pykrige
+    - nosetests -v ./test.py --with-coverage --cover-package=pykrige
 
 #after_success:
 #    coveralls

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,10 @@ Kriging Toolkit for Python
 .. image:: https://ci.appveyor.com/api/projects/status/github/bsmurphy/PyKrige?branch=master&svg=true
     :target: https://ci.appveyor.com/project/bsmurphy/pykrige
 
-.. image:: https://circleci.com/gh/bsmurphy/PyKrige/tree/master.svg?style=shield&circle-token=:circle-token
-    :target: https://circleci.com/gh/bsmurphy/PyKrige
+.. image:: https://readthedocs.org/projects/pykrige/badge/?version=latest
+    :target: http://pykrige.readthedocs.io/en/latest/?badge=latest
+    :alt: Documentation Status
+
 
 The code supports two- and three- dimensional ordinary and universal kriging. Standard variogram models (linear, power, spherical, gaussian, exponential) are built in, but custom variogram models can also be used with the code. The kriging methods are separated into four classes. Examples of their uses are shown below. The two-dimensional universal kriging code currently supports regional-linear, point-logarithmic, and external drift terms, while the three-dimensional universal kriging code supports a regional-linear drift term in all three spatial dimensions. Both universal kriging classes also support generic 'specified' and 'functional' drift capabilities. With the 'specified' drift capability, the user may manually specify the values of the drift(s) at each data point and all grid points. With the 'functional' drift capability, the user may provide callable function(s) of the spatial coordinates that define the drift(s). The package includes a module that contains functions that should be useful in working with ASCII grid files (`*.asc`).
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,0 @@
-dependencies:
-  pre:
-    - pip install numpy
-    - pip install scipy
-    - pip install matplotlib

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,4 @@
+scikit-learn>=0.18
+recommonmark
+sphinxcontrib-napoleon
+sphinx-gallery


### PR DESCRIPTION
This PR completes https://github.com/bsmurphy/PyKrige/pull/48 and allows the documentation to be automatically rendered at http://pykrige.readthedocs.io/en/latest/  for every new commit on master (fixes #14 ).

The Circle CI was originally added to build the documentation, but it is not longer necessary (since it can be built on readthedocs.io). 

@bsmurphy Could you please remove CircleCI from the list of services that have access to this repo (somewhere in the repo settings)? Thanks.