### PR TITLE
MNT Fix missing lapack_py3.pyx in MANIFEST.in  for v1.3.1

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -26,5 +26,7 @@ include pykrige/lib/__init__.py
 include pykrige/lib/cok.pyx
 include pykrige/lib/lapack.pxd
 include pykrige/lib/lapack.pyx
+include pykrige/lib/lapack_py3.pxd
+include pykrige/lib/lapack_py3.pxd
 include pykrige/lib/variogram_models.pxd
 include pykrige/lib/variogram_models.pyx

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,15 +3,9 @@ include README.md
 include CHANGELOG.md
 include setup.cfg
 include setup.py
-include pykrige/__init__.py
-include pykrige/kriging_tools.py
-include pykrige/ok3d.py
-include pykrige/ok.py
-include pykrige/uk3d.py
-include pykrige/uk.py
-include pykrige/variogram_models.py
-include pykrige/core.py
-include pykrige/test.py
+recursive-include pykrige *.py
+recursive-include pykrige *.pyx
+recursive-include pykrige *.pxd
 include pykrige/test_data/test_data.txt
 include pykrige/test_data/test1_answer.asc
 include pykrige/test_data/test1_settings.txt
@@ -22,11 +16,3 @@ include pykrige/test_data/test3_dem.asc
 include pykrige/test_data/test3_settings.txt
 include pykrige/test_data/test3d_answer.txt
 include pykrige/test_data/test3d_data.txt
-include pykrige/lib/__init__.py
-include pykrige/lib/cok.pyx
-include pykrige/lib/lapack.pxd
-include pykrige/lib/lapack.pyx
-include pykrige/lib/lapack_py3.pxd
-include pykrige/lib/lapack_py3.pxd
-include pykrige/lib/variogram_models.pxd
-include pykrige/lib/variogram_models.pyx

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,12 @@ environment:
     - PYTHON_VERSION: 2.7
       PYTHON_ARCH: "32"
       MINICONDA: C:\Miniconda
-    - PYTHON_VERSION: 3.4
-      PYTHON_ARCH: "64"
+    - PYTHON_VERSION: 3.5
+      PYTHON_ARCH: "32"
       MINICONDA: C:\Miniconda3
+    - PYTHON_VERSION: 3.6
+      PYTHON_ARCH: "64"
+      MINICONDA: C:\Miniconda3-x64
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %MINICONDA%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - "conda create -q -n krige-env python=%PYTHON_VERSION% numpy scipy nose matplotlib cython scikit-learn"
+  - "conda create -q -n krige-env python=%PYTHON_VERSION% numpy scipy nose matplotlib cython scikit-learn==0.18.2"
   - activate krige-env
   - pip install coverage
 

--- a/pykrige/__init__.py
+++ b/pykrige/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'Benjamin S. Murphy'
-__version__ = '1.3.1'
+__version__ = '1.4.dev0'
 __doc__ = """Code by Benjamin S. Murphy
 bscott.murphy@gmail.com
 


### PR DESCRIPTION
I'm currently trying to make a conda forge release for v1.3.1 in https://github.com/conda-forge/pykrige-feedstock/pull/1 and the Python 3 builds are failing because the .tar.gz on PyPi misses the `lapack_py3.{pyx,pxd}` files. This PR addresses this issue by adding them to `MANIFEST.in`. (Generally though maybe we shouldn't specify files one by one in `MANIFEST.in` and use wildcards instead).

@bsmurphy Once this is merged should we upload the fixed version on PyPi as 1.3.2? Since the current version will also fail to build with Cython on Python 3..

P.S: once someone reviews and merges this PR, I can make a new `1.3.X` branch from the `v1.3.1` tag and backport this commit there, then add another `v1.3.2` tag..
