### PR TITLE
FIX rendering of the kriging_1D.py example

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -52,6 +52,7 @@ clean:
 	rm -rf $(BUILDDIR)/*
 	rm -rf generated/
 	rm -rf auto_examples/
+	rm -rf examples/
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,7 @@
 scikit-learn>=0.18
+sphinx
+pillow
 recommonmark
+sphinx_rtd_theme
 sphinxcontrib-napoleon
 sphinx-gallery

--- a/examples/kriging_1D.py
+++ b/examples/kriging_1D.py
@@ -1,5 +1,6 @@
 """
 1D Kriging
+==========
 
 An example of 1D kriging with PyKrige
 """


### PR DESCRIPTION
Minor formatting changes to make the kriging_1D.py example link correctly in the [list of examples](http://pykrige.readthedocs.io/en/latest/examples/index.html). 

Also added missing requirements to generate the documentation locally.