### PR TITLE
DOC simplify the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ The code supports 2D and 3D ordinary and universal kriging. Standard variogram m
 See the `documentation <http://pykrige.readthedocs.io/en/latest/>`_ for more details.
 
 Installation
-------------
+^^^^^^^^^^^^
 
 PyKrige requires Python 2.7 or 3.5+ as well as numpy, scipy and matplotlib. It can be installed from PyPi with,
 
@@ -103,7 +103,7 @@ Parameter Tuning
 
 A scikit-learn compatible API for parameter tuning by cross-validation is exposed in `sklearn.model_selection.GridSearchCV <http://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html>`_. See the `Krige CV <http://pykrige.readthedocs.io/en/latest/examples/krige_cv.html#sphx-glr-examples-krige-cv-py>`_ example for a more practical illustration.
 
-In it's current form, the `pykrige.rk.Krige <http://pykrige.readthedocs.io/en/latest/generated/pykrige.rk.Krige.html#pykrige.rk.Krige>`_ class can be used to optimise all the common parameters of `OrdinaryKriging` and `UniversalKriging`.
+In it's current form, the `pykrige.rk.Krige <http://pykrige.readthedocs.io/en/latest/generated/pykrige.rk.Krige.html#pykrige.rk.Krige>`_ class can be used to optimise all the common parameters of ``OrdinaryKriging`` and ``UniversalKriging``.
 
 
 Regression Kriging
@@ -112,5 +112,8 @@ Regression Kriging
 `Regression kriging <https://en.wikipedia.org/wiki/Regression-Kriging>`_ can be performed with `pykrige.rk.RegressionKriging <http://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html>`_. This class takes as parameters a scikit-learn regression model, and details of either either the ``OrdinaryKriging`` or the ``UniversalKriging`` class, and performs a correction steps on the ML regression prediction.
  
 A demonstration of the regression kriging is provided in the `corresponding example <http://pykrige.readthedocs.io/en/latest/examples/regression_kriging2d.html#sphx-glr-examples-regression-kriging2d-py>`_.
+
+License
+^^^^^^^
 
 PyKrige uses the BSD 3-Clause License.

--- a/README.rst
+++ b/README.rst
@@ -21,28 +21,36 @@ Kriging Toolkit for Python
 
 
 
-The code supports two- and three- dimensional ordinary and universal kriging. Standard variogram models (linear, power, spherical, gaussian, exponential) are built in, but custom variogram models can also be used with the code. The kriging methods are separated into four classes. Examples of their uses are shown below. The two-dimensional universal kriging code currently supports regional-linear, point-logarithmic, and external drift terms, while the three-dimensional universal kriging code supports a regional-linear drift term in all three spatial dimensions. Both universal kriging classes also support generic 'specified' and 'functional' drift capabilities. With the 'specified' drift capability, the user may manually specify the values of the drift(s) at each data point and all grid points. With the 'functional' drift capability, the user may provide callable function(s) of the spatial coordinates that define the drift(s). The package includes a module that contains functions that should be useful in working with ASCII grid files (`*.asc`).
+The code supports 2D and 3D ordinary and universal kriging. Standard variogram models (linear, power, spherical, gaussian, exponential) are built in, but custom variogram models can also be used. The 2D universal kriging code currently supports regional-linear, point-logarithmic, and external drift terms, while the 3D universal kriging code supports a regional-linear drift term in all three spatial dimensions. Both universal kriging classes also support generic 'specified' and 'functional' drift capabilities. With the 'specified' drift capability, the user may manually specify the values of the drift(s) at each data point and all grid points. With the 'functional' drift capability, the user may provide callable function(s) of the spatial coordinates that define the drift(s). The package includes a module that contains functions that should be useful in working with ASCII grid files (`*.asc`).
 
-PyKrige is on PyPi, so installation is as simple as typing the following into a command line.
+See the `documentation <http://pykrige.readthedocs.io/en/latest/>`_ for more details.
+
+Installation
+------------
+
+PyKrige requires Python 2.7 or 3.5+ as well as numpy, scipy and matplotlib. It can be installed from PyPi with,
 
 .. code:: bash
 
     pip install pykrige
 
-To update PyKrige from PyPi, type the following into a command line.
+scikit-learn is an optional dependency needed for parameter tuning and regression kriging.
+
+
+If you use conda, PyKrige can be installed from the `conda-forge` channel with,
 
 .. code:: bash
 
-    pip install --upgrade pykrige
+    conda install -c conda-forge pykrige
 
-PyKrige uses the BSD 3-Clause License.
 
 Ordinary Kriging Example
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
+First we will create a 2D dataset together with the associated x, y grids,
+
 .. code:: python
 
-    from pykrige.ok import OrdinaryKriging
     import numpy as np
     import pykrige.kriging_tools as kt
     
@@ -54,126 +62,55 @@ Ordinary Kriging Example
     
     gridx = np.arange(0.0, 5.5, 0.5)
     gridy = np.arange(0.0, 5.5, 0.5)
+
+
+
+Then we create the ordinary kriging object. The required inputs are the X-coordinates of
+the data points, the Y-coordinates of the data points, and the Z-values of the
+data points. If no variogram model is specified, defaults to a linear variogram
+model. If no variogram model parameters are specified, then the code automatically
+calculates the parameters by fitting the variogram model to the binned 
+experimental semivariogram. The verbose kwarg controls code verbosity, and
+the ``enable_plotting`` kwarg controls the display of the semivariogram.
+
     
-    # Create the ordinary kriging object. Required inputs are the X-coordinates of
-    # the data points, the Y-coordinates of the data points, and the Z-values of the
-    # data points. If no variogram model is specified, defaults to a linear variogram
-    # model. If no variogram model parameters are specified, then the code automatically
-    # calculates the parameters by fitting the variogram model to the binned 
-    # experimental semivariogram. The verbose kwarg controls code talk-back, and
-    # the enable_plotting kwarg controls the display of the semivariogram.
+.. code:: python
+
+    from pykrige.ok import OrdinaryKriging
+
     OK = OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2], variogram_model='linear',
                          verbose=False, enable_plotting=False)
     					 
-    # Creates the kriged grid and the variance grid. Allows for kriging on a rectangular
-    # grid of points, on a masked rectangular grid of points, or with arbitrary points.
-    # (See OrdinaryKriging.__doc__ for more information.)
+Next, we will create the kriged grid and the variance grid. Kriging on a rectangular
+grid of points, on a masked rectangular grid of points, or with arbitrary points is allowed,
+
+.. code:: python
+
     z, ss = OK.execute('grid', gridx, gridy)
     
-    # Writes the kriged grid to an ASCII grid file.
+Finally, we write the kriged grid to an ASCII grid file,
+
+.. code:: python
+
     kt.write_asc_grid(gridx, gridy, z, filename="output.asc")
 
-Universal Kriging Example
-^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code:: python
-
-    from pykrige.uk import UniversalKriging
-    import numpy as np
-
-    data = np.array([[0.3, 1.2, 0.47],
-                     [1.9, 0.6, 0.56],
-                     [1.1, 3.2, 0.74],
-                     [3.3, 4.4, 1.47],
-                     [4.7, 3.8, 1.74]])
-
-    gridx = np.arange(0.0, 5.5, 0.5)
-    gridy = np.arange(0.0, 5.5, 0.5)
-
-    # Create the ordinary kriging object. Required inputs are the X-coordinates of
-    # the data points, the Y-coordinates of the data points, and the Z-values of the
-    # data points. Variogram is handled as in the ordinary kriging case.
-    # drift_terms is a list of the drift terms to include; currently supported terms
-    # are 'regional_linear', 'point_log', and 'external_Z'. Refer to 
-    # UniversalKriging.__doc__ for more information.
-    UK = UniversalKriging(data[:, 0], data[:, 1], data[:, 2], variogram_model='linear',
-                          drift_terms=['regional_linear'])
-                                             
-    # Creates the kriged grid and the variance grid. Allows for kriging on a rectangular
-    # grid of points, on a masked rectangular grid of points, or with arbitrary points.
-    # (See UniversalKriging.__doc__ for more information.)
-    z, ss = UK.execute('grid', gridx, gridy)
-
-Three-Dimensional Kriging Example
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. code:: python
-
-    from pykrige.ok3d import OrdinaryKriging3D
-    from pykrige.uk3d import UniversalKriging3D
-    import numpy as np
-
-    data = np.array([[0.1, 0.1, 0.3, 0.9],
-                                     [0.2, 0.1, 0.4, 0.8],
-                                     [0.1, 0.3, 0.1, 0.9],
-                                     [0.5, 0.4, 0.4, 0.5],
-                                     [0.3, 0.3, 0.2, 0.7]])
-
-    gridx = np.arange(0.0, 0.6, 0.05)
-    gridy = np.arange(0.0, 0.6, 0.01)
-    gridz = np.arange(0.0, 0.6, 0.1)
-
-    # Create the 3D ordinary kriging object and solves for the three-dimension kriged 
-    # volume and variance. Refer to OrdinaryKriging3D.__doc__ for more information.
-    ok3d = OrdinaryKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3],
-                                                     variogram_model='linear')
-    k3d, ss3d = ok3d.execute('grid', gridx, gridy, gridz)
-
-    # Create the 3D universal kriging object and solves for the three-dimension kriged 
-    # volume and variance. Refer to UniversalKriging3D.__doc__ for more information.
-    uk3d = UniversalKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3], 
-                                                      variogram_model='linear', drift_terms=['regional_linear'])
-    k3d, ss3d = uk3d.execute('grid', gridx, gridy, gridz)
-
-    # To use the generic 'specified' drift term, the user must provide the drift values 
-    # at each data point and at every grid point. The following example is equivalent to 
-    # using a linear drift in all three spatial dimensions. Refer to
-    # UniversalKriging3D.__doc__ for more information.
-    zg, yg, xg = np.meshgrid(gridz, gridy, gridx, indexing='ij')
-    uk3d = UniversalKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3], 
-                                                      variogram_model='linear', drift_terms=['specified'],
-                                                      specified_drift=[data[:, 0], data[:, 1]])
-    k3d, ss3d = uk3d.execute('grid', gridx, gridy, gridz, specified_drift_arrays=[xg, yg, zg])
-
-    # To use the generic 'functional' drift term, the user must provide a callable 
-    # function that takes only the spatial dimensions as arguments. The following example 
-    # is equivalent to using a linear drift only in the x-direction. Refer to 
-    # UniversalKriging3D.__doc__ for more information.
-    func = lambda x, y, z: x
-    uk3d = UniversalKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3], 
-                                                      variogram_model='linear', drift_terms=['functional'],
-                                                      functional_drift=[func])
-    k3d, ss3d = uk3d.execute('grid', gridx, gridy, gridz)
-
-    # Note that the use of the 'specified' and 'functional' generic drift capabilities is 
-    # essentially identical in the two-dimensional universal kriging class (except for a 
-    # difference in the number of spatial coordinates for the passed drift functions). 
-    # See UniversalKriging.__doc__ for more information.
+Other examples can be found in the `example gallery <http://pykrige.readthedocs.io/en/latest/examples/index.html>`_. 
 
 
-Kriging Parameters Tuning
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Parameter Tuning
+^^^^^^^^^^^^^^^^
 
-PyKrige also exposes a scikit learn compatible API, which can be used to perform parameter tuning including the krige algorithm using `sklearn.model_selection.GridSearchCV <http://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html>`_. Once `scikit-learn` is installed, you can run the corresponding example with
-`python path/to/examples/krige_cv.py`
+A scikit-learn compatible API for parameter tuning by cross-validation is exposed in `sklearn.model_selection.GridSearchCV <http://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html>`_. See the `Krige CV <http://pykrige.readthedocs.io/en/latest/examples/krige_cv.html#sphx-glr-examples-krige-cv-py>`_ example for a more practical illustration.
 
-In it's current form, the `pykrige.rk.Krige` class can be used to optimise all the common parameters of `OrdinaryKriging` and `UniversalKriging` classes.
+In it's current form, the `pykrige.rk.Krige <http://pykrige.readthedocs.io/en/latest/generated/pykrige.rk.Krige.html#pykrige.rk.Krige>`_ class can be used to optimise all the common parameters of `OrdinaryKriging` and `UniversalKriging`.
 
 
 Regression Kriging
 ^^^^^^^^^^^^^^^^^^
 
-PyKrige exposes a class `pykrige.rk.RegressionKriging` that can be used to perform `regression kriging <https://en.wikipedia.org/wiki/Regression-Kriging>`_. This class takes as parameters a `scikit-learn` regression model, and details of either the Ordinary/UniversalKriging class, and performs a correction steps on the ML regression prediction.
+`Regression kriging <https://en.wikipedia.org/wiki/Regression-Kriging>`_ can be performed with `pykrige.rk.RegressionKriging <http://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html>`_. This class takes as parameters a scikit-learn regression model, and details of either either the ``OrdinaryKriging`` or the ``UniversalKriging`` class, and performs a correction steps on the ML regression prediction.
  
-A demonstration of the regression kriging is provided in `examples.regression_kriging.py`. Once again, `scikit-learn` is required to use this functionality.
+A demonstration of the regression kriging is provided in the `corresponding example <http://pykrige.readthedocs.io/en/latest/examples/regression_kriging2d.html#sphx-glr-examples-regression-kriging2d-py>`_.
 
+PyKrige uses the BSD 3-Clause License.

--- a/README.rst
+++ b/README.rst
@@ -21,9 +21,17 @@ Kriging Toolkit for Python
 
 
 
-The code supports 2D and 3D ordinary and universal kriging. Standard variogram models (linear, power, spherical, gaussian, exponential) are built in, but custom variogram models can also be used. The 2D universal kriging code currently supports regional-linear, point-logarithmic, and external drift terms, while the 3D universal kriging code supports a regional-linear drift term in all three spatial dimensions. Both universal kriging classes also support generic 'specified' and 'functional' drift capabilities. With the 'specified' drift capability, the user may manually specify the values of the drift(s) at each data point and all grid points. With the 'functional' drift capability, the user may provide callable function(s) of the spatial coordinates that define the drift(s). The package includes a module that contains functions that should be useful in working with ASCII grid files (`*.asc`).
+The code supports 2D and 3D ordinary and universal kriging. Standard variogram models
+(linear, power, spherical, gaussian, exponential) are built in, but custom variogram models can also be used.
+The 2D universal kriging code currently supports regional-linear, point-logarithmic, and external drift terms,
+while the 3D universal kriging code supports a regional-linear drift term in all three spatial dimensions.
+Both universal kriging classes also support generic 'specified' and 'functional' drift capabilities.
+With the 'specified' drift capability, the user may manually specify the values of the drift(s) at each data
+point and all grid points. With the 'functional' drift capability, the user may provide callable function(s)
+of the spatial coordinates that define the drift(s). The package includes a module that contains functions
+that should be useful in working with ASCII grid files (`*.asc`).
 
-See the `documentation <http://pykrige.readthedocs.io/en/latest/>`_ for more details.
+See the `documentation <http://pykrige.readthedocs.io/>`_ for more details.
 
 Installation
 ^^^^^^^^^^^^
@@ -62,56 +70,132 @@ First we will create a 2D dataset together with the associated x, y grids,
     
     gridx = np.arange(0.0, 5.5, 0.5)
     gridy = np.arange(0.0, 5.5, 0.5)
-
-
-
-Then we create the ordinary kriging object. The required inputs are the X-coordinates of
-the data points, the Y-coordinates of the data points, and the Z-values of the
-data points. If no variogram model is specified, defaults to a linear variogram
-model. If no variogram model parameters are specified, then the code automatically
-calculates the parameters by fitting the variogram model to the binned 
-experimental semivariogram. The verbose kwarg controls code verbosity, and
-the ``enable_plotting`` kwarg controls the display of the semivariogram.
-
     
-.. code:: python
-
-    from pykrige.ok import OrdinaryKriging
-
+    # Create the ordinary kriging object. Required inputs are the X-coordinates of
+    # the data points, the Y-coordinates of the data points, and the Z-values of the
+    # data points. If no variogram model is specified, defaults to a linear variogram
+    # model. If no variogram model parameters are specified, then the code automatically
+    # calculates the parameters by fitting the variogram model to the binned 
+    # experimental semivariogram. The verbose kwarg controls code talk-back, and
+    # the enable_plotting kwarg controls the display of the semivariogram.
     OK = OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2], variogram_model='linear',
                          verbose=False, enable_plotting=False)
     					 
-Next, we will create the kriged grid and the variance grid. Kriging on a rectangular
-grid of points, on a masked rectangular grid of points, or with arbitrary points is allowed,
-
-.. code:: python
-
+    # Creates the kriged grid and the variance grid. Allows for kriging on a rectangular
+    # grid of points, on a masked rectangular grid of points, or with arbitrary points.
+    # (See OrdinaryKriging.__doc__ for more information.)
     z, ss = OK.execute('grid', gridx, gridy)
     
-Finally, we write the kriged grid to an ASCII grid file,
+    # Writes the kriged grid to an ASCII grid file.
+    kt.write_asc_grid(gridx, gridy, z, filename="output.asc")
+
+Universal Kriging Example
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code:: python
 
-    kt.write_asc_grid(gridx, gridy, z, filename="output.asc")
+    from pykrige.uk import UniversalKriging
+    import numpy as np
+
+    data = np.array([[0.3, 1.2, 0.47],
+                     [1.9, 0.6, 0.56],
+                     [1.1, 3.2, 0.74],
+                     [3.3, 4.4, 1.47],
+                     [4.7, 3.8, 1.74]])
+
+    gridx = np.arange(0.0, 5.5, 0.5)
+    gridy = np.arange(0.0, 5.5, 0.5)
+
+    # Create the ordinary kriging object. Required inputs are the X-coordinates of
+    # the data points, the Y-coordinates of the data points, and the Z-values of the
+    # data points. Variogram is handled as in the ordinary kriging case.
+    # drift_terms is a list of the drift terms to include; currently supported terms
+    # are 'regional_linear', 'point_log', and 'external_Z'. Refer to 
+    # UniversalKriging.__doc__ for more information.
+    UK = UniversalKriging(data[:, 0], data[:, 1], data[:, 2], variogram_model='linear',
+                          drift_terms=['regional_linear'])
+                                             
+    # Creates the kriged grid and the variance grid. Allows for kriging on a rectangular
+    # grid of points, on a masked rectangular grid of points, or with arbitrary points.
+    # (See UniversalKriging.__doc__ for more information.)
+    z, ss = UK.execute('grid', gridx, gridy)
+
+Three-Dimensional Kriging Example
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code:: python
+
+    from pykrige.ok3d import OrdinaryKriging3D
+    from pykrige.uk3d import UniversalKriging3D
+    import numpy as np
+
+    data = np.array([[0.1, 0.1, 0.3, 0.9],
+                                     [0.2, 0.1, 0.4, 0.8],
+                                     [0.1, 0.3, 0.1, 0.9],
+                                     [0.5, 0.4, 0.4, 0.5],
+                                     [0.3, 0.3, 0.2, 0.7]])
+
+    gridx = np.arange(0.0, 0.6, 0.05)
+    gridy = np.arange(0.0, 0.6, 0.01)
+    gridz = np.arange(0.0, 0.6, 0.1)
+
+    # Create the 3D ordinary kriging object and solves for the three-dimension kriged 
+    # volume and variance. Refer to OrdinaryKriging3D.__doc__ for more information.
+    ok3d = OrdinaryKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3],
+                                                     variogram_model='linear')
+    k3d, ss3d = ok3d.execute('grid', gridx, gridy, gridz)
+
+    # Create the 3D universal kriging object and solves for the three-dimension kriged 
+    # volume and variance. Refer to UniversalKriging3D.__doc__ for more information.
+    uk3d = UniversalKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3], 
+                                                      variogram_model='linear', drift_terms=['regional_linear'])
+    k3d, ss3d = uk3d.execute('grid', gridx, gridy, gridz)
+
+    # To use the generic 'specified' drift term, the user must provide the drift values 
+    # at each data point and at every grid point. The following example is equivalent to 
+    # using a linear drift in all three spatial dimensions. Refer to
+    # UniversalKriging3D.__doc__ for more information.
+    zg, yg, xg = np.meshgrid(gridz, gridy, gridx, indexing='ij')
+    uk3d = UniversalKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3], 
+                                                      variogram_model='linear', drift_terms=['specified'],
+                                                      specified_drift=[data[:, 0], data[:, 1]])
+    k3d, ss3d = uk3d.execute('grid', gridx, gridy, gridz, specified_drift_arrays=[xg, yg, zg])
+
+    # To use the generic 'functional' drift term, the user must provide a callable 
+    # function that takes only the spatial dimensions as arguments. The following example 
+    # is equivalent to using a linear drift only in the x-direction. Refer to 
+    # UniversalKriging3D.__doc__ for more information.
+    func = lambda x, y, z: x
+    uk3d = UniversalKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3], 
+                                                      variogram_model='linear', drift_terms=['functional'],
+                                                      functional_drift=[func])
+    k3d, ss3d = uk3d.execute('grid', gridx, gridy, gridz)
+
+    # Note that the use of the 'specified' and 'functional' generic drift capabilities is 
+    # essentially identical in the two-dimensional universal kriging class (except for a 
+    # difference in the number of spatial coordinates for the passed drift functions). 
+    # See UniversalKriging.__doc__ for more information.
 
 
-Other examples can be found in the `example gallery <http://pykrige.readthedocs.io/en/latest/examples/index.html>`_. 
+Kriging Parameters Tuning
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-
-Parameter Tuning
-^^^^^^^^^^^^^^^^
-
-A scikit-learn compatible API for parameter tuning by cross-validation is exposed in `sklearn.model_selection.GridSearchCV <http://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html>`_. See the `Krige CV <http://pykrige.readthedocs.io/en/latest/examples/krige_cv.html#sphx-glr-examples-krige-cv-py>`_ example for a more practical illustration.
-
-In it's current form, the `pykrige.rk.Krige <http://pykrige.readthedocs.io/en/latest/generated/pykrige.rk.Krige.html#pykrige.rk.Krige>`_ class can be used to optimise all the common parameters of ``OrdinaryKriging`` and ``UniversalKriging``.
+A scikit-learn compatible API for parameter tuning by cross-validation is exposed in
+`sklearn.model_selection.GridSearchCV <http://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html>`_.
+See the `Krige CV <http://pykrige.readthedocs.io/en/latest/examples/krige_cv.html#sphx-glr-examples-krige-cv-py>`_
+example for a more practical illustration.
 
 
 Regression Kriging
 ^^^^^^^^^^^^^^^^^^
 
-`Regression kriging <https://en.wikipedia.org/wiki/Regression-Kriging>`_ can be performed with `pykrige.rk.RegressionKriging <http://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html>`_. This class takes as parameters a scikit-learn regression model, and details of either either the ``OrdinaryKriging`` or the ``UniversalKriging`` class, and performs a correction steps on the ML regression prediction.
+`Regression kriging <https://en.wikipedia.org/wiki/Regression-Kriging>`_ can be performed
+with `pykrige.rk.RegressionKriging <http://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html>`_.
+This class takes as parameters a scikit-learn regression model, and details of either either
+the ``OrdinaryKriging`` or the ``UniversalKriging`` class, and performs a correction steps on the ML regression prediction.
  
-A demonstration of the regression kriging is provided in the `corresponding example <http://pykrige.readthedocs.io/en/latest/examples/regression_kriging2d.html#sphx-glr-examples-regression-kriging2d-py>`_.
+A demonstration of the regression kriging is provided in the 
+`corresponding example <http://pykrige.readthedocs.io/en/latest/examples/regression_kriging2d.html#sphx-glr-examples-regression-kriging2d-py>`_.
 
 License
 ^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@ Kriging Toolkit for Python
 .. image:: https://anaconda.org/conda-forge/pykrige/badges/version.svg
   :target: https://github.com/conda-forge/pykrige-feedstock
 
-.. image:: https://readthedocs.org/projects/pykrige/badge/?version=latest
-    :target: http://pykrige.readthedocs.io/en/latest/?badge=latest
+.. image:: https://readthedocs.org/projects/pykrige/badge/?version=stable
+    :target: http://pykrige.readthedocs.io/en/stable/?badge=stable
     :alt: Documentation Status
 
 .. image:: https://travis-ci.org/bsmurphy/PyKrige.svg?branch=master
@@ -31,7 +31,7 @@ point and all grid points. With the 'functional' drift capability, the user may 
 of the spatial coordinates that define the drift(s). The package includes a module that contains functions
 that should be useful in working with ASCII grid files (`*.asc`).
 
-See the `documentation <http://pykrige.readthedocs.io/>`_ for more details.
+See the documentation at `http://pykrige.readthedocs.io/en/stable/ <http://pykrige.readthedocs.io/en/stable/>`_ for more details.
 
 Installation
 ^^^^^^^^^^^^
@@ -182,7 +182,7 @@ Kriging Parameters Tuning
 
 A scikit-learn compatible API for parameter tuning by cross-validation is exposed in
 `sklearn.model_selection.GridSearchCV <http://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html>`_.
-See the `Krige CV <http://pykrige.readthedocs.io/en/latest/examples/krige_cv.html#sphx-glr-examples-krige-cv-py>`_
+See the `Krige CV <http://pykrige.readthedocs.io/en/stable/examples/krige_cv.html#sphx-glr-examples-krige-cv-py>`_
 example for a more practical illustration.
 
 
@@ -195,7 +195,7 @@ This class takes as parameters a scikit-learn regression model, and details of e
 the ``OrdinaryKriging`` or the ``UniversalKriging`` class, and performs a correction steps on the ML regression prediction.
  
 A demonstration of the regression kriging is provided in the 
-`corresponding example <http://pykrige.readthedocs.io/en/latest/examples/regression_kriging2d.html#sphx-glr-examples-regression-kriging2d-py>`_.
+`corresponding example <http://pykrige.readthedocs.io/en/stable/examples/regression_kriging2d.html#sphx-glr-examples-regression-kriging2d-py>`_.
 
 License
 ^^^^^^^

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,37 +7,35 @@ environment:
     # See: http://stackoverflow.com/a/13751649/163740
     WITH_COMPILER: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_compiler.cmd"
   matrix:
-    - PYTHON_VERSION: 2.7
+    - PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
       MINICONDA: C:\Miniconda-x64
-    - PYTHON_VERSION: 2.7
+    - PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "32"
       MINICONDA: C:\Miniconda
-    - PYTHON_VERSION: 3.5
+    - PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "32"
-      MINICONDA: C:\Miniconda3
-    - PYTHON_VERSION: 3.6
+      MINICONDA: C:\Miniconda35
+    - PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
-      MINICONDA: C:\Miniconda3-x64
+      MINICONDA: C:\Miniconda36-x64
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %MINICONDA%"
 
 install:
-  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PYTHON%\\Library\\bin;%PATH%"
   - conda config --set always_yes yes --set changeps1 no
   - conda info -a
-  - conda create -q -n krige-env python=%PYTHON_VERSION% numpy scipy nose matplotlib cython scikit-learn pytest pytest-cov
-  - activate krige-env
+  - conda install numpy scipy nose matplotlib cython scikit-learn pytest pytest-cov
   - pip install coverage
   - pip install -e .
 
 
 test_script:
-  - activate krige-env
   - pytest -sv --cov=pykrige pykrige/
   - ps: | 
-          d ".\\examples"
+          cd ".\\examples"
           Get-ChildItem ".\\" -Filter *.py | 
           Foreach-Object {
               python $_.FullName 2>&1 | Tee-Object -Append -FilePath "C:\\log.txt"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,9 +26,8 @@ init:
 install:
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
   - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
   - conda info -a
-  - "conda create -q -n krige-env python=%PYTHON_VERSION% numpy scipy nose matplotlib cython scikit-learn pytest pytest-cov"
+  - conda create -q -n krige-env python=%PYTHON_VERSION% numpy scipy nose matplotlib cython scikit-learn pytest pytest-cov
   - activate krige-env
   - pip install coverage
   - pip install -e .

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,12 @@ AUTHOR = 'Benjamin S. Murphy'
 EMAIL = 'bscott.murphy@gmail.com'
 URL = 'https://github.com/bsmurphy/PyKrige'
 DESC = 'Kriging Toolkit for Python'
-LDESC = 'PyKrige is a kriging toolkit for Python that supports two- and ' \
-        'three-dimensional ordinary and universal kriging.'
+
+with open('README.rst', 'r') as fh:
+    LDESC = fh.read()
+
 PACKAGES = ['pykrige']
-PCKG_DAT = {'pykrige': ['README.md', 'CHANGELOG.md', 'LICENSE.txt',
+PCKG_DAT = {'pykrige': ['README.rst', 'CHANGELOG.md', 'LICENSE.txt',
                         'MANIFEST.in', join('test_data', '*.txt'),
                         join('test_data', '*.asc')]}
 REQ = ['numpy', 'scipy', 'matplotlib']


### PR DESCRIPTION
This PR aims to simplify the readme, and improve linking to the documentation for the v1.4 release (#67). In particular, redundant examples are removed instead pointing to the example gallery.

The updated version can be viewed in https://github.com/rth/PyKrige/blob/simplify-readme/README.rst

Please let me know what you think.