### PR TITLE
Added a couple of methods to obtain the variogram model points or to save them to a file 

### DIFF
--- a/pykrige/ok.py
+++ b/pykrige/ok.py
@@ -404,19 +404,19 @@ class OrdinaryKriging:
                                         self.lags), 'k-')
         plt.show()
 
-    def get_variogram_model_points(self):
+    def get_variogram_points(self):
         """Obtain the data pairs for the variogram model.
-           It is possible to save the model to a file if output_file
-           indicates the full path to 
+           returns a numpy.array with the form [lag, variogram_value_at_lag]
         """
         variogram_points = self.variogram_function(self.variogram_model_parameters, self.lags)
 
         return np.array([self.lags, variogram_points])
 
     def save_variogram_to_file(self, output_file, separator=" "):
-        """Obtain the data pairs for the variogram model.
-           It is possible to save the model to a file if output_file
-           indicates the full path to 
+        """Save the variogram model to a file with name output_file 
+           with the form `lag variogram_value_at_lag` the separator
+           variable specifies which character will separate lags from
+           variogram values, and defaults to a single space.
         """
         variogram_points = self.variogram_function(self.variogram_model_parameters, self.lags)
 

--- a/pykrige/ok.py
+++ b/pykrige/ok.py
@@ -404,6 +404,34 @@ class OrdinaryKriging:
                                         self.lags), 'k-')
         plt.show()
 
+    def get_variogram_model_points(self):
+        """Obtain the data pairs for the variogram model.
+           It is possible to save the model to a file if output_file
+           indicates the full path to 
+        """
+        variogram_points = self.variogram_function(self.variogram_model_parameters, self.lags)
+
+        return np.array([self.lags, variogram_points])
+
+    def save_variogram_to_file(self, output_file, separator=" "):
+        """Obtain the data pairs for the variogram model.
+           It is possible to save the model to a file if output_file
+           indicates the full path to 
+        """
+        variogram_points = self.variogram_function(self.variogram_model_parameters, self.lags)
+
+        if output_file != None:
+            try:
+                with open(output_file,"w") as out:
+                    for l in range(len(self.lags)):
+                        print("{}{}{}".format(self.lags[l],
+                                              separator,
+                                              variogram_points[l]), file=out)
+            except IOError:
+                print("Couldn't save to file {}".format(output_file))
+            except:
+                print("An error has ocurred while saving {}".format(output_file))
+
     def switch_verbose(self):
         """Allows user to switch code talk-back on/off. Takes no arguments."""
         self.verbose = not self.verbose

--- a/pykrige/ok.py
+++ b/pykrige/ok.py
@@ -405,32 +405,14 @@ class OrdinaryKriging:
         plt.show()
 
     def get_variogram_points(self):
-        """Obtain the data pairs for the variogram model.
-           returns a numpy.array with the form [lag, variogram_value_at_lag]
+        """Obtain the evaluation of the variogram function at each of the
+        provided lags.
+
+        Returns
+        -------
+        returns the evaluation of the variogram_function at each of the lags
         """
-        variogram_points = self.variogram_function(self.variogram_model_parameters, self.lags)
-
-        return np.array([self.lags, variogram_points])
-
-    def save_variogram_to_file(self, output_file, separator=" "):
-        """Save the variogram model to a file with name output_file 
-           with the form `lag variogram_value_at_lag` the separator
-           variable specifies which character will separate lags from
-           variogram values, and defaults to a single space.
-        """
-        variogram_points = self.variogram_function(self.variogram_model_parameters, self.lags)
-
-        if output_file != None:
-            try:
-                with open(output_file,"w") as out:
-                    for l in range(len(self.lags)):
-                        print("{}{}{}".format(self.lags[l],
-                                              separator,
-                                              variogram_points[l]), file=out)
-            except IOError:
-                print("Couldn't save to file {}".format(output_file))
-            except:
-                print("An error has ocurred while saving {}".format(output_file))
+        return self.lags, self.variogram_function(self.variogram_model_parameters, self.lags)
 
     def switch_verbose(self):
         """Allows user to switch code talk-back on/off. Takes no arguments."""

--- a/pykrige/ok.py
+++ b/pykrige/ok.py
@@ -405,12 +405,19 @@ class OrdinaryKriging:
         plt.show()
 
     def get_variogram_points(self):
-        """Obtain the evaluation of the variogram function at each of the
-        provided lags.
+        """Returns both the lags and the variogram function evaluated at each
+        of them.
+
+        The evaluation of the variogram function and the lags are produced
+        internally. This method is convenient when the user wants to access to
+        the lags and the resulting variogram (according to the model provided)
+        for further analysis.
 
         Returns
         -------
-        returns the evaluation of the variogram_function at each of the lags
+        (tuple) tuple containing:
+            lags (array) - the lags at which the variogram was evaluated
+            variogram (array) - the variogram function evaluated at the lags
         """
         return self.lags, self.variogram_function(self.variogram_model_parameters, self.lags)
 

--- a/pykrige/tests/test_core.py
+++ b/pykrige/tests/test_core.py
@@ -395,6 +395,32 @@ def test_ok_update_variogram_model(validation_ref):
     assert anisotropy_angle != ok.anisotropy_angle
 
 
+def test_ok_get_variogram_points(validation_ref):
+    # Test to compare the variogram of OK results to those obtained using
+    # KT3D_H2O.
+    # (M. Karanovic, M. Tonkin, and D. Wilson, 2009, Groundwater,
+    # vol. 47, no. 4, 580-586.)
+
+    # Variogram parameters
+    _variogram_parameters = [500.0, 3000.0, 0.0]
+
+    data, _, (ok_test_answer, gridx, gridy) = validation_ref
+    
+    ok = OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2],
+                          variogram_model='exponential',
+                          variogram_parameters=_variogram_parameters)
+
+    # Get the variogram points from the UniversalKriging instance
+    lags, calculated_variogram = ok.get_variogram_points()
+
+    # Generate the expected variogram points according to the
+    # exponential variogram model 
+    expected_variogram = variogram_models.exponential_variogram_model(
+                         _variogram_parameters, lags)
+
+    assert_allclose(calculated_variogram, expected_variogram)
+
+
 def test_ok_execute(sample_data_2d):
 
     data, (gridx, gridy, _), mask_ref = sample_data_2d
@@ -542,6 +568,33 @@ def test_uk_update_variogram_model(sample_data_2d):
     assert variogram_parameters != uk.variogram_model_parameters
     assert anisotropy_scaling != uk.anisotropy_scaling
     assert anisotropy_angle != uk.anisotropy_angle
+
+
+def test_uk_get_variogram_points(validation_ref):
+    # Test to compare the variogram of UK with linear drift to results from 
+    # KT3D_H2O.
+    # (M. Karanovic, M. Tonkin, and D. Wilson, 2009, Groundwater,
+    # vol. 47, no. 4, 580-586.)
+
+    # Variogram parameters
+    _variogram_parameters = [500.0, 3000.0, 0.0]
+
+    data, _, (uk_test_answer, gridx, gridy) = validation_ref
+    
+    uk = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
+                          variogram_model='exponential',
+                          variogram_parameters=_variogram_parameters,
+                          drift_terms=['regional_linear'])
+
+    # Get the variogram points from the UniversalKriging instance
+    lags, calculated_variogram = uk.get_variogram_points()
+
+    # Generate the expected variogram points according to the
+    # exponential variogram model 
+    expected_variogram = variogram_models.exponential_variogram_model(
+                         _variogram_parameters, lags)
+
+    assert_allclose(calculated_variogram, expected_variogram)
 
 
 def test_uk_calculate_data_point_zscalars(sample_data_2d):

--- a/pykrige/uk.py
+++ b/pykrige/uk.py
@@ -615,6 +615,34 @@ class UniversalKriging:
                                         self.lags), 'k-')
         plt.show()
 
+    def get_variogram_model_points(self):
+        """Obtain the data pairs for the variogram model.
+           It is possible to save the model to a file if output_file
+           indicates the full path to 
+        """
+        variogram_points = self.variogram_function(self.variogram_model_parameters, self.lags)
+
+        return np.array([self.lags, variogram_points])
+
+    def save_variogram_to_file(self, output_file, separator=" "):
+        """Obtain the data pairs for the variogram model.
+           It is possible to save the model to a file if output_file
+           indicates the full path to 
+        """
+        variogram_points = self.variogram_function(self.variogram_model_parameters, self.lags)
+
+        if output_file != None:
+            try:
+                with open(output_file,"w") as out:
+                    for l in range(len(self.lags)):
+                        print("{}{}{}".format(self.lags[l],
+                                              separator,
+                                              variogram_points[l]), file=out)
+            except IOError:
+                print("Couldn't save to file {}".format(output_file))
+            except:
+                print("An error has ocurred while saving {}".format(output_file))
+
     def switch_verbose(self):
         """Allows user to switch code talk-back on/off. Takes no arguments."""
         self.verbose = not self.verbose

--- a/pykrige/uk.py
+++ b/pykrige/uk.py
@@ -616,12 +616,19 @@ class UniversalKriging:
         plt.show()
 
     def get_variogram_points(self):
-        """Obtain the evaluation of the variogram function at each of the
-        provided lags.
+        """Returns both the lags and the variogram function evaluated at each
+        of them.
+
+        The evaluation of the variogram function and the lags are produced
+        internally. This method is convenient when the user wants to access to
+        the lags and the resulting variogram (according to the model provided)
+        for further analysis.
 
         Returns
         -------
-        returns the evaluation of the variogram_function at each of the lags
+        (tuple) tuple containing:
+            lags (array) - the lags at which the variogram was evaluated
+            variogram (array) - the variogram function evaluated at the lags
         """
         return self.lags, self.variogram_function(self.variogram_model_parameters, self.lags)
 

--- a/pykrige/uk.py
+++ b/pykrige/uk.py
@@ -616,32 +616,14 @@ class UniversalKriging:
         plt.show()
 
     def get_variogram_points(self):
-        """Obtain the data pairs for the variogram model.
-           returns a numpy.array with the form [lag, variogram_value_at_lag]
+        """Obtain the evaluation of the variogram function at each of the
+        provided lags.
+
+        Returns
+        -------
+        returns the evaluation of the variogram_function at each of the lags
         """
-        variogram_points = self.variogram_function(self.variogram_model_parameters, self.lags)
-
-        return np.array([self.lags, variogram_points])
-
-    def save_variogram_to_file(self, output_file, separator=" "):
-        """Save the variogram model to a file with name output_file 
-           with the form `lag variogram_value_at_lag` the separator
-           variable specifies which character will separate lags from
-           variogram values, and defaults to a single space.
-        """
-        variogram_points = self.variogram_function(self.variogram_model_parameters, self.lags)
-
-        if output_file != None:
-            try:
-                with open(output_file,"w") as out:
-                    for l in range(len(self.lags)):
-                        print("{}{}{}".format(self.lags[l],
-                                              separator,
-                                              variogram_points[l]), file=out)
-            except IOError:
-                print("Couldn't save to file {}".format(output_file))
-            except:
-                print("An error has ocurred while saving {}".format(output_file))
+        return self.lags, self.variogram_function(self.variogram_model_parameters, self.lags)
 
     def switch_verbose(self):
         """Allows user to switch code talk-back on/off. Takes no arguments."""

--- a/pykrige/uk.py
+++ b/pykrige/uk.py
@@ -615,19 +615,19 @@ class UniversalKriging:
                                         self.lags), 'k-')
         plt.show()
 
-    def get_variogram_model_points(self):
+    def get_variogram_points(self):
         """Obtain the data pairs for the variogram model.
-           It is possible to save the model to a file if output_file
-           indicates the full path to 
+           returns a numpy.array with the form [lag, variogram_value_at_lag]
         """
         variogram_points = self.variogram_function(self.variogram_model_parameters, self.lags)
 
         return np.array([self.lags, variogram_points])
 
     def save_variogram_to_file(self, output_file, separator=" "):
-        """Obtain the data pairs for the variogram model.
-           It is possible to save the model to a file if output_file
-           indicates the full path to 
+        """Save the variogram model to a file with name output_file 
+           with the form `lag variogram_value_at_lag` the separator
+           variable specifies which character will separate lags from
+           variogram values, and defaults to a single space.
         """
         variogram_points = self.variogram_function(self.variogram_model_parameters, self.lags)
 


### PR DESCRIPTION
Hi, I've added a couple of methods to UniversalKriging and OrdinaryKriging:

* `get_variogram_points`: wich returns a numpy.array `[lags, variogram_value_at_lags]` which can be used of interest for the user (for further computations).   
* `save_variogram_to_file`: wich saves the variogram to a file `output_file` with separator `separator`(which defaults to space ` `) with the format `lag variogram_value_at_lag` according to the separator. Making a call with separator="," would save the values as `lag,variogram_value_at_lag`.   